### PR TITLE
Add lightweight browser-based SysML v2 editor

### DIFF
--- a/doc/web-editor/README.md
+++ b/doc/web-editor/README.md
@@ -1,0 +1,24 @@
+# SysML v2 Web Editor
+
+This lightweight, client-side web application provides a convenient place to sketch textual SysML v2 models from a browser.
+
+## Features
+
+- CodeMirror-based editor with line numbers, bracket matching, and a dark/light theme toggle.
+- Quick access toolbar to create new models, open existing `.sysml` files, download the current model, and insert a starter template.
+- Automatically generated model outline built from common SysML declarations such as `package`, `part`, `interface`, `action`, `constraint`, and `requirement`.
+- Heuristic validation that spots unmatched `end` blocks and curly braces.
+
+## Getting Started
+
+1. Open `index.html` in a modern browser (Chrome, Edge, Firefox, or Safari).
+2. Start typing SysML v2 text into the editor.
+3. Use the outline on the right to navigate to major declarations.
+4. Click **Download** to save the current model to a `.sysml` file.
+
+> **Note:** The application runs entirely in the browser and does not upload or store any content on a server.
+
+## Development Notes
+
+- The editor depends on the CodeMirror 5 CDN for syntax highlighting. Network access is required the first time you open the page so the scripts can be cached by your browser.
+- `editor.js` contains the minimal outline and validation heuristics; extend this file if you want to integrate a full SysML v2 parser.

--- a/doc/web-editor/editor.js
+++ b/doc/web-editor/editor.js
@@ -1,0 +1,241 @@
+(function () {
+  const editorElement = document.getElementById("editor");
+  const outlineElement = document.getElementById("outline");
+  const validationElement = document.getElementById("validation-status");
+  const fileInput = document.getElementById("file-input");
+  const themeToggle = document.getElementById("toggle-theme");
+
+  const sysmlKeywords = [
+    "package",
+    "part",
+    "interface",
+    "action",
+    "state",
+    "transition",
+    "subject",
+    "import",
+    "item",
+    "attribute",
+    "operation",
+    "end",
+    "constraint",
+    "requirement",
+    "view",
+    "viewpoint",
+    "usecase",
+    "association",
+    "relationship",
+  ];
+
+  const cm = CodeMirror.fromTextArea(editorElement, {
+    mode: {
+      name: "clike",
+      keywords: sysmlKeywords.join(" "),
+      blockKeywords: sysmlKeywords.join(" "),
+      atoms: "true false",
+    },
+    lineNumbers: true,
+    matchBrackets: true,
+    tabSize: 2,
+    indentUnit: 2,
+    autofocus: true,
+    autoCloseBrackets: true,
+    extraKeys: {
+      "Ctrl-S": () => downloadModel(),
+      "Cmd-S": () => downloadModel(),
+      "Ctrl-Space": () => showValidation(),
+    },
+  });
+
+  const defaultTemplate = `package Example::SynchronousMotor {
+  import SysML::Standard;
+
+  part controller : Controller;
+  part motor : Motor;
+
+  interface Controller {
+    attribute torqueCommand : Real;
+    action regulateSpeed();
+  }
+
+  interface Motor {
+    attribute actualSpeed : Real;
+    action applyTorque();
+  }
+
+  constraint MaintainSpeed {
+    regulatedSpeed >= 0.0;
+  }
+}
+`;
+
+  cm.setValue(defaultTemplate);
+  updateOutline(defaultTemplate);
+  showValidation();
+
+  document.getElementById("btn-new").addEventListener("click", () => {
+    if (cm.getValue().trim().length === 0 || confirm("Discard current model?")) {
+      cm.setValue("");
+      cm.focus();
+    }
+  });
+
+  document.getElementById("btn-insert").addEventListener("click", () => {
+    const current = cm.getValue();
+    if (current.trim().length === 0) {
+      cm.setValue(defaultTemplate);
+    } else {
+      cm.replaceRange(`\n${defaultTemplate}`, cm.getCursor());
+    }
+    cm.focus();
+  });
+
+  document.getElementById("btn-open").addEventListener("click", () => {
+    fileInput.click();
+  });
+
+  document.getElementById("btn-save").addEventListener("click", downloadModel);
+
+  const debouncedValidation = debounce(showValidation, 400);
+
+  cm.on("change", () => {
+    const content = cm.getValue();
+    updateOutline(content);
+    debouncedValidation();
+  });
+
+  fileInput.addEventListener("change", async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const text = await file.text();
+    cm.setValue(text);
+    cm.focus();
+    updateOutline(text);
+    showValidation();
+    fileInput.value = "";
+  });
+
+  const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  if (prefersDark) {
+    themeToggle.checked = true;
+    document.body.classList.add("dark");
+  }
+
+  themeToggle.addEventListener("change", () => {
+    document.body.classList.toggle("dark", themeToggle.checked);
+    cm.refresh();
+  });
+
+  function downloadModel() {
+    const content = cm.getValue();
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `model-${new Date().toISOString().replace(/[:.]/g, "-")}.sysml`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function showValidation() {
+    const content = cm.getValue();
+    const diagnostics = validate(content);
+    if (diagnostics.length === 0) {
+      validationElement.textContent = "No structural issues detected.";
+      validationElement.className = "status success";
+    } else {
+      validationElement.innerHTML = diagnostics
+        .map((diag) => `<span class="issue">${diag}</span>`)
+        .join(" ");
+      validationElement.className = "status warning";
+    }
+  }
+
+  function updateOutline(content) {
+    const outline = buildOutline(content);
+    outlineElement.innerHTML = "";
+    if (outline.length === 0) {
+      const empty = document.createElement("li");
+      empty.textContent = "No structural elements detected.";
+      empty.className = "empty";
+      outlineElement.appendChild(empty);
+      return;
+    }
+
+    for (const item of outline) {
+      const li = document.createElement("li");
+      const name = document.createElement("span");
+      name.textContent = item.name;
+      const kind = document.createElement("span");
+      kind.textContent = item.kind;
+      kind.className = "kind";
+      li.appendChild(name);
+      li.appendChild(kind);
+      li.addEventListener("click", () => {
+        cm.setCursor({ line: item.line, ch: 0 });
+        cm.focus();
+      });
+      outlineElement.appendChild(li);
+    }
+  }
+
+  function buildOutline(content) {
+    const outline = [];
+    const regex = /^(\s*)(package|part|interface|action|state|transition|constraint|requirement|view|viewpoint|usecase)\s+([A-Za-z0-9_:]+)/i;
+    const lines = content.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      const match = line.match(regex);
+      if (match) {
+        outline.push({
+          line: index,
+          indent: match[1].length,
+          kind: match[2],
+          name: match[3],
+        });
+      }
+    });
+    return outline;
+  }
+
+  function validate(content) {
+    const diagnostics = [];
+    const stack = [];
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, index) => {
+      const trimmed = line.trim();
+      if (/^(package|interface|action|constraint|state|view|viewpoint|requirement)\b/i.test(trimmed)) {
+        const keyword = trimmed.split(/\s+/)[0];
+        stack.push({ keyword, line: index + 1 });
+      }
+      if (/^end\b/i.test(trimmed)) {
+        const scope = stack.pop();
+        if (!scope) {
+          diagnostics.push(`Line ${index + 1}: unexpected 'end'.`);
+        }
+      }
+    });
+
+    for (const scope of stack.reverse()) {
+      diagnostics.push(`Line ${scope.line}: '${scope.keyword}' has no matching 'end'.`);
+    }
+
+    const unclosedBraces = (content.match(/\{/g) || []).length - (content.match(/\}/g) || []).length;
+    if (unclosedBraces > 0) {
+      diagnostics.push(`${unclosedBraces} unmatched '{' detected.`);
+    } else if (unclosedBraces < 0) {
+      diagnostics.push(`${Math.abs(unclosedBraces)} unmatched '}' detected.`);
+    }
+
+    return diagnostics;
+  }
+
+  function debounce(fn, delay) {
+    let handle;
+    return function () {
+      clearTimeout(handle);
+      handle = setTimeout(fn, delay);
+    };
+  }
+})();

--- a/doc/web-editor/index.html
+++ b/doc/web-editor/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SysML v2 Web Editor</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>SysML v2 Web Editor</h1>
+      <nav class="toolbar">
+        <button id="btn-new" type="button">New Model</button>
+        <button id="btn-open" type="button">Open...</button>
+        <button id="btn-save" type="button">Download</button>
+        <button id="btn-insert" type="button">Insert Template</button>
+        <label class="theme-toggle">
+          <input type="checkbox" id="toggle-theme" />
+          <span>Dark theme</span>
+        </label>
+        <input id="file-input" type="file" accept=".sysml,.txt,.kerml,.kerml2,.md,.json" hidden />
+      </nav>
+    </header>
+    <main class="layout">
+      <section class="editor-pane">
+        <textarea id="editor" aria-label="SysML model editor"></textarea>
+      </section>
+      <aside class="side-pane">
+        <section class="panel">
+          <h2>Model Outline</h2>
+          <ul id="outline" aria-live="polite"></ul>
+        </section>
+        <section class="panel">
+          <h2>Validation</h2>
+          <p id="validation-status" class="status">Start typing to validate your model.</p>
+        </section>
+        <section class="panel">
+          <h2>Help</h2>
+          <p>
+            Use this lightweight editor to sketch SysML v2 textual models. Download your
+            work as a <code>.sysml</code> file or paste it into other SysML v2 tooling.
+          </p>
+          <p>
+            The outline is generated heuristically from key declarations such as
+            <code>package</code>, <code>part</code>, <code>interface</code>, and
+            <code>action</code> blocks.
+          </p>
+        </section>
+      </aside>
+    </main>
+    <footer class="app-footer">
+      <span>SysML v2 Web Editor — Experimental utility for quick prototyping</span>
+    </footer>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/mode/clike/clike.min.js"></script>
+    <script src="editor.js"></script>
+  </body>
+</html>

--- a/doc/web-editor/styles.css
+++ b/doc/web-editor/styles.css
@@ -1,0 +1,216 @@
+:root {
+  color-scheme: light dark;
+  --background: #f8f9fb;
+  --panel: #ffffff;
+  --border: #d0d7de;
+  --text: #1f2328;
+  --accent: #0061d5;
+  --accent-contrast: #ffffff;
+  --header-bg: #14213d;
+  --header-text: #f8f9fb;
+  --footer-bg: #f1f3f6;
+  --footer-text: #3f454d;
+}
+
+body.dark {
+  --background: #0f172a;
+  --panel: #111b2e;
+  --border: #1e293b;
+  --text: #e2e8f0;
+  --accent: #38bdf8;
+  --accent-contrast: #0f172a;
+  --header-bg: #020617;
+  --header-text: #e2e8f0;
+  --footer-bg: #020617;
+  --footer-text: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+  background: var(--background);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 1rem 1.5rem;
+  background: var(--header-bg);
+  color: var(--header-text);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.16);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.toolbar button {
+  background: var(--accent);
+  border: 1px solid transparent;
+  color: var(--accent-contrast);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.3s ease;
+}
+
+.toolbar button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(56, 189, 248, 0.35);
+}
+
+.toolbar button:active {
+  transform: translateY(0);
+  box-shadow: inset 0 2px 4px rgba(15, 23, 42, 0.35);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--header-text);
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(18rem, 28rem);
+  gap: 1px;
+  background: var(--border);
+  min-height: 0;
+}
+
+.editor-pane {
+  min-height: 0;
+  background: var(--panel);
+  display: flex;
+  flex-direction: column;
+}
+
+.CodeMirror {
+  flex: 1;
+  height: 100% !important;
+  font-size: 0.95rem;
+  background: transparent;
+}
+
+.side-pane {
+  background: var(--panel);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.panel {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.08);
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.05rem;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.status.success {
+  color: #15803d;
+}
+
+.status.warning {
+  color: #9a3412;
+}
+
+.status .issue {
+  display: block;
+}
+
+#outline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+#outline li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  background: rgba(59, 130, 246, 0.07);
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+#outline li:hover {
+  background: rgba(59, 130, 246, 0.18);
+}
+
+#outline span.kind {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+body.dark #outline li {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+body.dark #outline li:hover {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.app-footer {
+  padding: 0.75rem 1.5rem;
+  background: var(--footer-bg);
+  color: var(--footer-text);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .side-pane {
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone browser-based SysML v2 editor under `doc/web-editor`
- implement CodeMirror-powered editing with outline, validation, and theme toggle helpers
- document how to launch and use the editor for quick SysML prototyping

## Testing
- Manual verification of the web editor in a browser

------
https://chatgpt.com/codex/tasks/task_e_68e66770a148832f89e6db88c3a133c3