### PR TITLE
Add versions lock for SysML v2 release dependencies

### DIFF
--- a/versions.lock
+++ b/versions.lock
@@ -1,0 +1,5 @@
+# Latest stable release tags pinned while OMG final PDFs are pending.
+# Specifications were formally adopted on 2025-06-30; pin to avoid churn as final PDFs may still be published later in 2025.
+SysML-v2-Release: 2025-07
+SysML-v2-API-Services: 2025-07
+SysML-v2-Pilot-Implementation: 2025-07


### PR DESCRIPTION
## Summary
- add a versions.lock file that pins the latest stable release tags for the SysML v2 Release, API Services, and Pilot Implementation repositories
- document the recent OMG adoption status to clarify why the pins are needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e671584a14832fa6356c8c185a4021