### PR TITLE
Add docker-compose setup for SysML API and Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: up logs down
+
+up:
+	@docker compose up -d
+
+logs:
+	@docker compose logs -f
+
+down:
+	@docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: sysml2
+      POSTGRES_USER: sysml2
+      POSTGRES_PASSWORD: sysml2
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    image: ghcr.io/systems-modeling/sysml-v2-api-services:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/sysml2
+      SPRING_DATASOURCE_USERNAME: sysml2
+      SPRING_DATASOURCE_PASSWORD: sysml2
+    ports:
+      - "9000:9000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/docs || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- add a docker-compose file to run Postgres alongside SysML-v2-API-Services
- configure service health checks and default database credentials
- provide Makefile tasks to start, stop, and tail the stack

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e671d39158832fbb5ea8e1b45c0ce6