### PR TITLE
Add TypeScript SDK scaffolding for SysML API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sysml-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK wrapper with lightweight runtime validation for the SysML v2 API.",
+  "license": "LGPL-3.0-or-later",
+  "type": "module",
+  "scripts": {
+    "build": "echo 'TypeScript sources only – no build step configured.'",
+    "test": "echo 'No automated tests available.'"
+  }
+}

--- a/src/generated/client.ts
+++ b/src/generated/client.ts
@@ -1,0 +1,336 @@
+import {
+  CommitListResponseSchema,
+  CommitResponseSchema,
+  CreateCommitRequestSchema,
+  CreateProjectRequestSchema,
+  ElementResponseSchema,
+  ElementUpsertSchema,
+  ErrorResponseSchema,
+  ListElementsResponseSchema,
+  ProjectListResponseSchema,
+  ProjectResponseSchema,
+} from './schemas';
+import type {
+  CommitListResponse,
+  CommitResponse,
+  CreateCommitParams,
+  CreateProjectParams,
+  DeleteElementParams,
+  DeleteProjectParams,
+  ElementResponse,
+  GetCommitParams,
+  GetElementParams,
+  GetProjectParams,
+  ListCommitsParams,
+  ListElementsParams,
+  ListElementsResponse,
+  ListProjectsParams,
+  ProjectListResponse,
+  ProjectResponse,
+  UpdateElementParams,
+  CreateElementParams,
+} from './types';
+import { ZodError, z, type ZodType } from '../utils/zod-lite';
+
+export interface RetryOptions {
+  retries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+}
+
+export interface SysMLClientConfig {
+  baseUrl: string;
+  token?: string;
+  retry?: RetryOptions;
+  fetchImpl?: typeof fetch;
+}
+
+export type RequestErrorCause =
+  | { type: 'network'; error: Error }
+  | { type: 'validation'; error: ZodError }
+  | { type: 'http'; status: number; body?: unknown };
+
+export class SysMLRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly causeDetail: RequestErrorCause,
+    public readonly response?: Response,
+  ) {
+    super(message);
+    this.name = 'SysMLRequestError';
+  }
+}
+
+const QueryParamSchema = z.record(z.any());
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildQuery(params?: Record<string, unknown>): string {
+  if (!params) {
+    return '';
+  }
+  const qp = QueryParamSchema.parse(params);
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(qp)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, String(item));
+      }
+    } else {
+      searchParams.append(key, String(value));
+    }
+  }
+  const result = searchParams.toString();
+  return result ? `?${result}` : '';
+}
+
+interface RequestOptions<TResponse> {
+  path: string;
+  method: HttpMethod;
+  query?: Record<string, unknown>;
+  requestBody?: unknown;
+  requestSchema?: ZodType<any>;
+  responseSchema: { parse(value: unknown): TResponse };
+}
+
+export class SysMLApiClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly retry: Required<RetryOptions>;
+
+  constructor(private readonly config: SysMLClientConfig) {
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.retry = {
+      retries: config.retry?.retries ?? 3,
+      baseDelayMs: config.retry?.baseDelayMs ?? 300,
+      maxDelayMs: config.retry?.maxDelayMs ?? 4000,
+      backoffFactor: config.retry?.backoffFactor ?? 2,
+    };
+  }
+
+  private async request<TResponse>({
+    path,
+    method,
+    query,
+    requestBody,
+    requestSchema,
+    responseSchema,
+  }: RequestOptions<TResponse>): Promise<TResponse> {
+    const url = `${this.config.baseUrl}${path}${buildQuery(query)}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.config.token) {
+      headers.Authorization = `Bearer ${this.config.token}`;
+    }
+
+    let parsedBody: unknown = requestBody;
+    if (requestSchema) {
+      try {
+        parsedBody = requestSchema.parse(requestBody);
+      } catch (err) {
+        if (err instanceof ZodError) {
+          throw new SysMLRequestError('Request body validation failed', { type: 'validation', error: err });
+        }
+        throw err;
+      }
+    }
+
+    let attempt = 0;
+    let delay = this.retry.baseDelayMs;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      attempt += 1;
+      try {
+        const response = await this.fetchImpl(url, {
+          method,
+          headers,
+          body: parsedBody !== undefined ? JSON.stringify(parsedBody) : undefined,
+        });
+
+        if (!response.ok) {
+          let errorBody: unknown;
+          try {
+            const text = await response.text();
+            errorBody = text ? JSON.parse(text) : undefined;
+          } catch (err) {
+            errorBody = undefined;
+          }
+
+          const parsedError = errorBody ? ErrorResponseSchema.safeParse(errorBody) : undefined;
+          const message = parsedError?.success
+            ? `${parsedError.data.errorCode}: ${parsedError.data.message}`
+            : `Request failed with status ${response.status}`;
+
+          throw new SysMLRequestError(message, { type: 'http', status: response.status, body: errorBody }, response);
+        }
+
+        if (response.status === 204) {
+          return undefined as TResponse;
+        }
+
+        const raw = await response.json();
+        try {
+          return responseSchema.parse(raw);
+        } catch (err) {
+          if (err instanceof ZodError) {
+            throw new SysMLRequestError('Response validation failed', { type: 'validation', error: err }, response);
+          }
+          throw err;
+        }
+      } catch (error) {
+        const isRetryable =
+          error instanceof SysMLRequestError &&
+          error.causeDetail.type === 'http' &&
+          error.causeDetail.status >= 500 &&
+          attempt <= this.retry.retries;
+
+        if (isRetryable) {
+          await sleep(Math.min(delay, this.retry.maxDelayMs));
+          delay *= this.retry.backoffFactor;
+          continue;
+        }
+
+        if (error instanceof SysMLRequestError) {
+          throw error;
+        }
+
+        if (attempt <= this.retry.retries) {
+          await sleep(Math.min(delay, this.retry.maxDelayMs));
+          delay *= this.retry.backoffFactor;
+          continue;
+        }
+
+        throw new SysMLRequestError('Network request failed', { type: 'network', error: error as Error });
+      }
+    }
+  }
+
+  listProjects(params?: ListProjectsParams): Promise<ProjectListResponse> {
+    return this.request({
+      path: '/projects',
+      method: 'GET',
+      query: params,
+      responseSchema: ProjectListResponseSchema,
+    });
+  }
+
+  createProject(params: CreateProjectParams): Promise<ProjectResponse> {
+    return this.request({
+      path: '/projects',
+      method: 'POST',
+      requestBody: params.body,
+      requestSchema: CreateProjectRequestSchema,
+      responseSchema: ProjectResponseSchema,
+    });
+  }
+
+  getProject(params: GetProjectParams): Promise<ProjectResponse> {
+    return this.request({
+      path: `/projects/${encodeURIComponent(params.projectId)}`,
+      method: 'GET',
+      responseSchema: ProjectResponseSchema,
+    });
+  }
+
+  deleteProject(params: DeleteProjectParams): Promise<void> {
+    return this.request({
+      path: `/projects/${encodeURIComponent(params.projectId)}`,
+      method: 'DELETE',
+      responseSchema: { parse: () => undefined },
+    });
+  }
+
+  listCommits(params: ListCommitsParams): Promise<CommitListResponse> {
+    const { projectId, ...query } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits`,
+      method: 'GET',
+      query,
+      responseSchema: CommitListResponseSchema,
+    });
+  }
+
+  createCommit(params: CreateCommitParams): Promise<CommitResponse> {
+    const { projectId, body } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits`,
+      method: 'POST',
+      requestBody: body,
+      requestSchema: CreateCommitRequestSchema,
+      responseSchema: CommitResponseSchema,
+    });
+  }
+
+  getCommit(params: GetCommitParams): Promise<CommitResponse> {
+    const { projectId, commitId } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}`,
+      method: 'GET',
+      responseSchema: CommitResponseSchema,
+    });
+  }
+
+  listElements(params: ListElementsParams): Promise<ListElementsResponse> {
+    const { projectId, commitId, ...query } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}/elements`,
+      method: 'GET',
+      query,
+      responseSchema: ListElementsResponseSchema,
+    });
+  }
+
+  createElement(params: CreateElementParams): Promise<ElementResponse> {
+    const { projectId, commitId, body } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}/elements`,
+      method: 'POST',
+      requestBody: body,
+      requestSchema: ElementUpsertSchema,
+      responseSchema: ElementResponseSchema,
+    });
+  }
+
+  getElement(params: GetElementParams): Promise<ElementResponse> {
+    const { projectId, commitId, elementId } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}/elements/${encodeURIComponent(
+        elementId,
+      )}`,
+      method: 'GET',
+      responseSchema: ElementResponseSchema,
+    });
+  }
+
+  updateElement(params: UpdateElementParams): Promise<ElementResponse> {
+    const { projectId, commitId, elementId, body } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}/elements/${encodeURIComponent(
+        elementId,
+      )}`,
+      method: 'PUT',
+      requestBody: body,
+      requestSchema: ElementUpsertSchema,
+      responseSchema: ElementResponseSchema,
+    });
+  }
+
+  deleteElement(params: DeleteElementParams): Promise<void> {
+    const { projectId, commitId, elementId } = params;
+    return this.request({
+      path: `/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}/elements/${encodeURIComponent(
+        elementId,
+      )}`,
+      method: 'DELETE',
+      responseSchema: { parse: () => undefined },
+    });
+  }
+}

--- a/src/generated/schemas.ts
+++ b/src/generated/schemas.ts
@@ -1,0 +1,120 @@
+import { z } from '../utils/zod-lite';
+import type {
+  ChangeOperation,
+  CommitListResponse,
+  CommitResponse,
+  CommitSummary,
+  CreateCommitRequest,
+  CreateProjectRequest,
+  ElementRecord,
+  ElementResponse,
+  ElementUpsert,
+  ErrorResponse,
+  ListElementsResponse,
+  ProjectListResponse,
+  ProjectResponse,
+  ProjectSummary,
+} from './types';
+
+export const ErrorResponseSchema = z.object({
+  errorCode: z.string(),
+  message: z.string(),
+  details: z.record(z.any()).optional(),
+});
+
+export const ProjectSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  defaultBranch: z.string(),
+});
+
+export const ProjectListResponseSchema = z.object({
+  items: ProjectSummarySchema.array(),
+});
+
+export const ProjectResponseSchema = z.object({
+  data: ProjectSummarySchema,
+});
+
+export const CreateProjectRequestSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  defaultBranch: z.string().optional(),
+});
+
+export const CommitSummarySchema = z.object({
+  id: z.string(),
+  message: z.string(),
+  author: z.string(),
+  createdAt: z.string(),
+  parentIds: z.array(z.string()),
+  branchId: z.string(),
+});
+
+export const CommitListResponseSchema = z.object({
+  items: CommitSummarySchema.array(),
+  cursor: z.string().optional(),
+});
+
+export const CommitResponseSchema = z.object({
+  data: CommitSummarySchema,
+});
+
+export const ElementUpsertSchema = z.object({
+  classifierId: z.string(),
+  name: z.string().optional(),
+  documentation: z.string().optional(),
+  payload: z.record(z.any()),
+});
+
+export const ChangeOperationSchema = z.union([
+  z.object({ type: z.literal('create'), element: ElementUpsertSchema }),
+  z.object({ type: z.literal('update'), elementId: z.string(), patch: ElementUpsertSchema }),
+  z.object({ type: z.literal('delete'), elementId: z.string() }),
+]);
+
+export const CreateCommitRequestSchema = z.object({
+  message: z.string(),
+  parentCommitId: z.string().optional(),
+  branchId: z.string().optional(),
+  operations: ChangeOperationSchema.array(),
+});
+
+export const ElementRecordSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  commitId: z.string(),
+  classifierId: z.string(),
+  name: z.string().optional(),
+  documentation: z.string().optional(),
+  payload: z.record(z.any()),
+});
+
+export const ElementResponseSchema = z.object({
+  data: ElementRecordSchema,
+});
+
+export const ListElementsResponseSchema = z.object({
+  items: ElementRecordSchema.array(),
+  cursor: z.string().optional(),
+});
+
+export type {
+  ErrorResponse,
+  ProjectSummary,
+  ProjectListResponse,
+  ProjectResponse,
+  CreateProjectRequest,
+  CommitSummary,
+  CommitListResponse,
+  CommitResponse,
+  ChangeOperation,
+  CreateCommitRequest,
+  ElementUpsert,
+  ElementRecord,
+  ElementResponse,
+  ListElementsResponse,
+};

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -1,0 +1,152 @@
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  defaultBranch: string;
+}
+
+export interface ProjectListResponse {
+  items: ProjectSummary[];
+}
+
+export interface CreateProjectRequest {
+  name: string;
+  description?: string;
+  defaultBranch?: string;
+}
+
+export interface CommitSummary {
+  id: string;
+  message: string;
+  author: string;
+  createdAt: string;
+  parentIds: string[];
+  branchId: string;
+}
+
+export interface CommitListResponse {
+  items: CommitSummary[];
+  cursor?: string;
+}
+
+export interface CreateCommitRequest {
+  message: string;
+  parentCommitId?: string;
+  branchId?: string;
+  operations: ChangeOperation[];
+}
+
+export type ChangeOperation =
+  | { type: 'create'; element: ElementUpsert }
+  | { type: 'update'; elementId: string; patch: ElementUpsert }
+  | { type: 'delete'; elementId: string };
+
+export interface ElementUpsert {
+  classifierId: string;
+  name?: string;
+  documentation?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ElementRecord {
+  id: string;
+  projectId: string;
+  commitId: string;
+  classifierId: string;
+  name?: string;
+  documentation?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ErrorResponse {
+  errorCode: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface ListCommitsParams {
+  projectId: string;
+  branchId?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface CreateCommitParams {
+  projectId: string;
+  body: CreateCommitRequest;
+}
+
+export interface GetCommitParams {
+  projectId: string;
+  commitId: string;
+}
+
+export interface ListProjectsParams {
+  search?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface CreateProjectParams {
+  body: CreateProjectRequest;
+}
+
+export interface GetProjectParams {
+  projectId: string;
+}
+
+export interface DeleteProjectParams {
+  projectId: string;
+}
+
+export interface ListElementsParams {
+  projectId: string;
+  commitId: string;
+  classifierId?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListElementsResponse {
+  items: ElementRecord[];
+  cursor?: string;
+}
+
+export interface GetElementParams {
+  projectId: string;
+  commitId: string;
+  elementId: string;
+}
+
+export interface CreateElementParams {
+  projectId: string;
+  commitId: string;
+  body: ElementUpsert;
+}
+
+export interface UpdateElementParams {
+  projectId: string;
+  commitId: string;
+  elementId: string;
+  body: ElementUpsert;
+}
+
+export interface DeleteElementParams {
+  projectId: string;
+  commitId: string;
+  elementId: string;
+}
+
+export interface ElementResponse {
+  data: ElementRecord;
+}
+
+export interface ProjectResponse {
+  data: ProjectSummary;
+}
+
+export interface CommitResponse {
+  data: CommitSummary;
+}

--- a/src/sysml-sdk.ts
+++ b/src/sysml-sdk.ts
@@ -1,0 +1,194 @@
+import { SysMLApiClient, SysMLRequestError, type SysMLClientConfig } from './generated/client';
+import type {
+  CommitListResponse,
+  CommitResponse,
+  CreateCommitParams,
+  CreateElementParams,
+  CreateProjectParams,
+  DeleteElementParams,
+  DeleteProjectParams,
+  ElementResponse,
+  GetCommitParams,
+  GetElementParams,
+  GetProjectParams,
+  ListCommitsParams,
+  ListElementsParams,
+  ListElementsResponse,
+  ListProjectsParams,
+  ProjectListResponse,
+  ProjectResponse,
+  UpdateElementParams,
+} from './generated/types';
+import { ZodError } from './utils/zod-lite';
+
+export type { SysMLClientConfig } from './generated/client';
+export type {
+  CommitListResponse,
+  CommitResponse,
+  CreateCommitParams,
+  CreateElementParams,
+  CreateProjectParams,
+  DeleteElementParams,
+  DeleteProjectParams,
+  ElementResponse,
+  GetCommitParams,
+  GetElementParams,
+  GetProjectParams,
+  ListCommitsParams,
+  ListElementsParams,
+  ListElementsResponse,
+  ListProjectsParams,
+  ProjectListResponse,
+  ProjectResponse,
+  UpdateElementParams,
+} from './generated/types';
+
+export abstract class SysMLError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'SysMLError';
+  }
+}
+
+export class SysMLValidationError extends SysMLError {
+  constructor(public readonly issues: ZodError['issues']) {
+    super('Validation failed', issues);
+    this.name = 'SysMLValidationError';
+  }
+}
+
+export class SysMLHttpError extends SysMLError {
+  constructor(public readonly status: number, public readonly body?: unknown) {
+    super(`HTTP ${status}`);
+    this.name = 'SysMLHttpError';
+  }
+}
+
+export class SysMLNetworkError extends SysMLError {
+  constructor(public readonly original: Error) {
+    super(original.message, original);
+    this.name = 'SysMLNetworkError';
+  }
+}
+
+export interface SysMLSDKConfig extends SysMLClientConfig {}
+
+export class SysMLSDK {
+  private readonly client: SysMLApiClient;
+
+  constructor(config: SysMLSDKConfig) {
+    this.client = new SysMLApiClient(config);
+  }
+
+  private transformError(error: unknown): never {
+    if (error instanceof SysMLRequestError) {
+      const detail = error.causeDetail;
+      if (detail.type === 'validation') {
+        throw new SysMLValidationError(detail.error.issues);
+      }
+      if (detail.type === 'http') {
+        throw new SysMLHttpError(detail.status, detail.body);
+      }
+      if (detail.type === 'network') {
+        throw new SysMLNetworkError(detail.error);
+      }
+    }
+    throw error;
+  }
+
+  async listProjects(params?: ListProjectsParams): Promise<ProjectListResponse> {
+    try {
+      return await this.client.listProjects(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async createProject(params: CreateProjectParams): Promise<ProjectResponse> {
+    try {
+      return await this.client.createProject(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async getProject(params: GetProjectParams): Promise<ProjectResponse> {
+    try {
+      return await this.client.getProject(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async deleteProject(params: DeleteProjectParams): Promise<void> {
+    try {
+      await this.client.deleteProject(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async listCommits(params: ListCommitsParams): Promise<CommitListResponse> {
+    try {
+      return await this.client.listCommits(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async createCommit(params: CreateCommitParams): Promise<CommitResponse> {
+    try {
+      return await this.client.createCommit(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async getCommit(params: GetCommitParams): Promise<CommitResponse> {
+    try {
+      return await this.client.getCommit(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async listElements(params: ListElementsParams): Promise<ListElementsResponse> {
+    try {
+      return await this.client.listElements(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async createElement(params: CreateElementParams): Promise<ElementResponse> {
+    try {
+      return await this.client.createElement(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async getElement(params: GetElementParams): Promise<ElementResponse> {
+    try {
+      return await this.client.getElement(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async updateElement(params: UpdateElementParams): Promise<ElementResponse> {
+    try {
+      return await this.client.updateElement(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async deleteElement(params: DeleteElementParams): Promise<void> {
+    try {
+      await this.client.deleteElement(params);
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+}

--- a/src/utils/zod-lite.ts
+++ b/src/utils/zod-lite.ts
@@ -1,0 +1,293 @@
+export type ZodIssue = {
+  path: (string | number)[];
+  message: string;
+};
+
+export class ZodError extends Error {
+  constructor(public readonly issues: ZodIssue[]) {
+    super(issues.length ? issues[0].message : 'Invalid data');
+    this.name = 'ZodError';
+  }
+}
+
+export abstract class ZodType<T> {
+  optional(): ZodType<T | undefined> {
+    return new ZodOptional(this);
+  }
+
+  nullable(): ZodType<T | null> {
+    return new ZodNullable(this);
+  }
+
+  array(): ZodArray<T> {
+    return new ZodArray(this);
+  }
+
+  default(value: T): ZodType<T> {
+    return new ZodDefault(this, value);
+  }
+
+  parse(value: unknown): T {
+    const result = this.safeParse(value);
+    if (!result.success) {
+      throw new ZodError(result.error);
+    }
+    return result.data;
+  }
+
+  safeParse(value: unknown): { success: true; data: T } | { success: false; error: ZodIssue[] } {
+    try {
+      return { success: true, data: this._parse(value, []) };
+    } catch (err) {
+      if (err instanceof ZodError) {
+        return { success: false, error: err.issues };
+      }
+      throw err;
+    }
+  }
+
+  protected abstract _parse(value: unknown, path: (string | number)[]): T;
+}
+
+class ZodString extends ZodType<string> {
+  constructor(private readonly checks: ((value: string, path: (string | number)[]) => void)[] = []) {
+    super();
+  }
+
+  min(length: number, message = `Expected string of length at least ${length}`): ZodString {
+    return new ZodString([...this.checks, (value, path) => {
+      if (value.length < length) {
+        throw new ZodError([{ path, message }]);
+      }
+    }]);
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): string {
+    if (typeof value !== 'string') {
+      throw new ZodError([{ path, message: 'Expected string' }]);
+    }
+    for (const check of this.checks) {
+      check(value, path);
+    }
+    return value;
+  }
+}
+
+class ZodNumber extends ZodType<number> {
+  constructor(private readonly checks: ((value: number, path: (string | number)[]) => void)[] = []) {
+    super();
+  }
+
+  nonnegative(message = 'Expected non-negative number'): ZodNumber {
+    return new ZodNumber([...this.checks, (value, path) => {
+      if (value < 0) {
+        throw new ZodError([{ path, message }]);
+      }
+    }]);
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): number {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      throw new ZodError([{ path, message: 'Expected number' }]);
+    }
+    for (const check of this.checks) {
+      check(value, path);
+    }
+    return value;
+  }
+}
+
+class ZodBoolean extends ZodType<boolean> {
+  protected _parse(value: unknown, path: (string | number)[]): boolean {
+    if (typeof value !== 'boolean') {
+      throw new ZodError([{ path, message: 'Expected boolean' }]);
+    }
+    return value;
+  }
+}
+
+class ZodLiteral<T> extends ZodType<T> {
+  constructor(private readonly literalValue: T) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T {
+    if (value !== this.literalValue) {
+      throw new ZodError([{ path, message: `Expected literal ${JSON.stringify(this.literalValue)}` }]);
+    }
+    return value as T;
+  }
+}
+
+class ZodEnum<T extends string> extends ZodType<T> {
+  constructor(private readonly values: readonly T[]) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T {
+    if (typeof value !== 'string' || !this.values.includes(value as T)) {
+      throw new ZodError([{ path, message: `Expected one of ${this.values.join(', ')}` }]);
+    }
+    return value as T;
+  }
+}
+
+class ZodArray<T> extends ZodType<T[]> {
+  constructor(private readonly element: ZodType<T>) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T[] {
+    if (!Array.isArray(value)) {
+      throw new ZodError([{ path, message: 'Expected array' }]);
+    }
+    return value.map((item, index) => this.element._parse(item, [...path, index]));
+  }
+}
+
+class ZodOptional<T> extends ZodType<T | undefined> {
+  constructor(private readonly inner: ZodType<T>) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    return this.inner._parse(value, path);
+  }
+}
+
+class ZodNullable<T> extends ZodType<T | null> {
+  constructor(private readonly inner: ZodType<T>) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T | null {
+    if (value === null) {
+      return null;
+    }
+    return this.inner._parse(value, path);
+  }
+}
+
+class ZodDefault<T> extends ZodType<T> {
+  constructor(private readonly inner: ZodType<T>, private readonly defaultValue: T) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T {
+    if (value === undefined) {
+      return this.defaultValue;
+    }
+    return this.inner._parse(value, path);
+  }
+}
+
+class ZodRecord<T> extends ZodType<Record<string, T>> {
+  constructor(private readonly value: ZodType<T>) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): Record<string, T> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      throw new ZodError([{ path, message: 'Expected object record' }]);
+    }
+    const result: Record<string, T> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = this.value._parse(val, [...path, key]);
+    }
+    return result;
+  }
+}
+
+class ZodAny extends ZodType<any> {
+  protected _parse(value: unknown, _path: (string | number)[]): any {
+    return value;
+  }
+}
+
+type ZodShape = Record<string, ZodType<any>>;
+
+type InferredShape<S extends ZodShape> = {
+  [K in keyof S]: S[K] extends ZodType<infer U> ? U : never;
+};
+
+class ZodObject<S extends ZodShape> extends ZodType<InferredShape<S>> {
+  constructor(private readonly shape: S) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): InferredShape<S> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      throw new ZodError([{ path, message: 'Expected object' }]);
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(this.shape)) {
+      const schema = this.shape[key];
+      const childPath = [...path, key];
+      const inputValue = (value as Record<string, unknown>)[key];
+      result[key] = schema._parse(inputValue, childPath);
+    }
+    return result as InferredShape<S>;
+  }
+
+  merge<OtherShape extends ZodShape>(other: ZodObject<OtherShape>): ZodObject<S & OtherShape> {
+    return new ZodObject({ ...(this.shape as any), ...(other.shape as any) });
+  }
+}
+
+class ZodUnion<T> extends ZodType<T> {
+  constructor(private readonly options: ZodType<any>[]) {
+    super();
+  }
+
+  protected _parse(value: unknown, path: (string | number)[]): T {
+    const errors: ZodIssue[][] = [];
+    for (const option of this.options) {
+      const result = option.safeParse(value);
+      if (result.success) {
+        return result.data as T;
+      }
+      errors.push(result.error);
+    }
+    throw new ZodError(errors.flat());
+  }
+}
+
+export const z = {
+  string(): ZodString {
+    return new ZodString();
+  },
+  number(): ZodNumber {
+    return new ZodNumber();
+  },
+  boolean(): ZodBoolean {
+    return new ZodBoolean();
+  },
+  literal<T extends string | number | boolean>(value: T): ZodLiteral<T> {
+    return new ZodLiteral(value);
+  },
+  enum<T extends string>(values: readonly [T, ...T[]]): ZodEnum<T> {
+    return new ZodEnum(values);
+  },
+  object<S extends ZodShape>(shape: S): ZodObject<S> {
+    return new ZodObject(shape);
+  },
+  array<T>(schema: ZodType<T>): ZodArray<T> {
+    return new ZodArray(schema);
+  },
+  union<T extends [ZodType<any>, ZodType<any>, ...ZodType<any>[]]>(schemas: T): ZodUnion<
+    T[number] extends ZodType<infer U> ? U : never
+  > {
+    return new ZodUnion(schemas);
+  },
+  record<T>(schema: ZodType<T>): ZodRecord<T> {
+    return new ZodRecord(schema);
+  },
+  any(): ZodAny {
+    return new ZodAny();
+  },
+};
+
+export type infer<T extends ZodType<any>> = T extends ZodType<infer U> ? U : never;


### PR DESCRIPTION
## Summary
- add a lightweight Zod-compatible runtime validation utility and generated TypeScript models for SysML API resources
- implement a fetch-based API client with retry/backoff logic and structured error reporting
- expose a high-level SysML SDK wrapper with typed methods and error specializations

## Testing
- not run (TypeScript toolchain unavailable in sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e671f6387c832f99d4e8543d47146d