### PR TITLE
Add Vitest integration tests covering SysML API flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "license": "LGPL-3.0-or-later",
   "type": "module",
   "scripts": {
-    "build": "echo 'TypeScript sources only – no build step configured.'",
-    "test": "echo 'No automated tests available.'"
+    "build": "echo 'TypeScript sources only \u2013 no build step configured.'",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.3",
+    "typescript": "^5.5.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/tests/api/element-crud.test.ts
+++ b/tests/api/element-crud.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, afterAll, expect } from 'vitest';
+import { sdk } from './fixtures/sdk';
+import { describeIfApi, testIfApi } from './fixtures/test-helpers';
+import { createProjectParams } from './fixtures/project';
+import { requirementDefinitionFixture } from './fixtures/element';
+import { ensureLatestCommit } from './fixtures/commit';
+
+describeIfApi('Element CRUD operations', () => {
+  const projectParams = createProjectParams();
+  const elementFixture = requirementDefinitionFixture();
+
+  let projectId: string;
+  let commitId: string;
+  let elementId: string;
+
+  beforeAll(async () => {
+    const project = await sdk.createProject(projectParams);
+    projectId = project.data.id;
+
+    const latestCommit = await ensureLatestCommit(projectId, project.data.defaultBranch);
+    commitId = latestCommit.id;
+  });
+
+  afterAll(async () => {
+    if (projectId) {
+      try {
+        await sdk.deleteProject({ projectId });
+      } catch (error) {
+        console.warn('Failed to delete test project', error);
+      }
+    }
+  });
+
+  testIfApi('creates an element in the workspace commit', async () => {
+    const element = await sdk.createElement({
+      projectId,
+      commitId,
+      body: elementFixture.create,
+    });
+
+    elementId = element.data.id;
+    expect(element.data.classifierId).toBe(elementFixture.create.classifierId);
+    expect(element.data.name).toBe(elementFixture.create.name);
+  });
+
+  testIfApi('retrieves the created element', async () => {
+    const response = await sdk.getElement({ projectId, commitId, elementId });
+    expect(response.data.id).toBe(elementId);
+    expect(response.data.name).toBe(elementFixture.create.name);
+  });
+
+  testIfApi('updates the element metadata', async () => {
+    const response = await sdk.updateElement({
+      projectId,
+      commitId,
+      elementId,
+      body: elementFixture.update,
+    });
+
+    expect(response.data.id).toBe(elementId);
+    expect(response.data.name).toBe(elementFixture.update.name);
+    expect(response.data.documentation).toBe(elementFixture.update.documentation);
+  });
+
+  testIfApi('lists elements filtered by classifier', async () => {
+    const response = await sdk.listElements({
+      projectId,
+      commitId,
+      classifierId: elementFixture.update.classifierId,
+      limit: 20,
+    });
+
+    const ids = response.items.map((item) => item.id);
+    expect(ids).toContain(elementId);
+  });
+
+  testIfApi('deletes the element from the workspace', async () => {
+    await sdk.deleteElement({ projectId, commitId, elementId });
+
+    const response = await sdk.listElements({
+      projectId,
+      commitId,
+      classifierId: elementFixture.update.classifierId,
+    });
+
+    const ids = response.items.map((item) => item.id);
+    expect(ids).not.toContain(elementId);
+  });
+});

--- a/tests/api/fixtures/commit.ts
+++ b/tests/api/fixtures/commit.ts
@@ -1,0 +1,21 @@
+import type { CommitResponse } from '../../../src/sysml-sdk';
+import { sdk } from './sdk';
+
+export async function ensureLatestCommit(projectId: string, branchId: string): Promise<CommitResponse['data']> {
+  const commits = await sdk.listCommits({ projectId, branchId, limit: 1 });
+  const latest = commits.items.at(0);
+  if (latest) {
+    return latest;
+  }
+
+  const created = await sdk.createCommit({
+    projectId,
+    body: {
+      message: 'Initialize branch for integration testing',
+      branchId,
+      operations: [],
+    },
+  });
+
+  return created.data;
+}

--- a/tests/api/fixtures/element.ts
+++ b/tests/api/fixtures/element.ts
@@ -1,0 +1,37 @@
+import type { ElementUpsert } from '../../../src/sysml-sdk';
+import { uniqueName } from './test-helpers';
+
+export interface ElementFixture {
+  create: ElementUpsert;
+  update: ElementUpsert;
+}
+
+export function requirementDefinitionFixture(): ElementFixture {
+  const baseName = uniqueName('sdk-requirement');
+  return {
+    create: {
+      classifierId: 'sysml:RequirementDefinition',
+      name: `${baseName}-create`,
+      documentation: 'Initial requirement definition created via integration test.',
+      payload: {
+        '@type': 'RequirementDefinition',
+        declaredName: `${baseName}-Create`,
+        declaredShortName: `${baseName}-C`,
+        text: ['The system shall demonstrate integration coverage.'],
+        reqId: `${baseName}-001`,
+      },
+    },
+    update: {
+      classifierId: 'sysml:RequirementDefinition',
+      name: `${baseName}-update`,
+      documentation: 'Updated requirement definition via integration test.',
+      payload: {
+        '@type': 'RequirementDefinition',
+        declaredName: `${baseName}-Updated`,
+        declaredShortName: `${baseName}-U`,
+        text: ['The system shall demonstrate updated integration coverage.'],
+        reqId: `${baseName}-002`,
+      },
+    },
+  };
+}

--- a/tests/api/fixtures/project.ts
+++ b/tests/api/fixtures/project.ts
@@ -1,0 +1,11 @@
+import type { CreateProjectParams } from '../../../src/sysml-sdk';
+import { uniqueName } from './test-helpers';
+
+export function createProjectParams(): CreateProjectParams {
+  return {
+    body: {
+      name: uniqueName('sdk-integration-project'),
+      description: 'Integration test project created by SysML SDK Vitest suite.',
+    },
+  };
+}

--- a/tests/api/fixtures/sdk.ts
+++ b/tests/api/fixtures/sdk.ts
@@ -1,0 +1,20 @@
+import { SysMLSDK } from '../../../src/sysml-sdk';
+
+const defaultBaseUrl = 'http://localhost:9000/api';
+
+const baseUrl = process.env.SYSML_API_URL ?? defaultBaseUrl;
+const token = process.env.SYSML_API_TOKEN;
+
+export const sdk = new SysMLSDK({ baseUrl, token });
+
+async function probeApi(): Promise<boolean> {
+  try {
+    await sdk.listProjects({ limit: 1 });
+    return true;
+  } catch (error) {
+    console.warn('[sysml-sdk] Unable to reach SysML API:', error);
+    return false;
+  }
+}
+
+export const apiAvailablePromise: Promise<boolean> = probeApi();

--- a/tests/api/fixtures/test-helpers.ts
+++ b/tests/api/fixtures/test-helpers.ts
@@ -1,0 +1,13 @@
+import { apiAvailablePromise } from './sdk';
+
+const availability = await apiAvailablePromise;
+
+export const describeIfApi = availability ? describe : describe.skip;
+export const itIfApi = availability ? it : it.skip;
+export const testIfApi = itIfApi;
+
+export function uniqueName(prefix: string): string {
+  const random = Math.random().toString(36).slice(2, 8);
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+  return `${prefix}-${timestamp}-${random}`;
+}

--- a/tests/api/project-flow.test.ts
+++ b/tests/api/project-flow.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, afterAll, expect } from 'vitest';
+import { sdk } from './fixtures/sdk';
+import { createProjectParams } from './fixtures/project';
+import { describeIfApi, testIfApi } from './fixtures/test-helpers';
+import { ensureLatestCommit } from './fixtures/commit';
+
+describeIfApi('Project and commit flows', () => {
+  const projectParams = createProjectParams();
+  let projectId: string;
+  let defaultBranch: string;
+  let latestCommitId: string | undefined;
+
+  beforeAll(async () => {
+    const project = await sdk.createProject(projectParams);
+    projectId = project.data.id;
+    defaultBranch = project.data.defaultBranch;
+  });
+
+  afterAll(async () => {
+    if (projectId) {
+      try {
+        await sdk.deleteProject({ projectId });
+      } catch (error) {
+        console.warn('Failed to delete test project', error);
+      }
+    }
+  });
+
+  testIfApi('lists the created project via search', async () => {
+    const response = await sdk.listProjects({ search: projectParams.body.name });
+    const ids = response.items.map((item) => item.id);
+    expect(ids).toContain(projectId);
+  });
+
+  testIfApi('retrieves project metadata', async () => {
+    const response = await sdk.getProject({ projectId });
+    expect(response.data.id).toBe(projectId);
+    expect(response.data.defaultBranch).toBe(defaultBranch);
+  });
+
+  testIfApi('creates and fetches a commit on the default branch', async () => {
+    const latest = await ensureLatestCommit(projectId, defaultBranch);
+    const commit = await sdk.createCommit({
+      projectId,
+      body: {
+        message: 'Integration test commit',
+        branchId: defaultBranch,
+        parentCommitId: latest.id,
+        operations: [],
+      },
+    });
+
+    latestCommitId = commit.data.id;
+    expect(commit.data.branchId).toBe(defaultBranch);
+
+    const fetched = await sdk.getCommit({ projectId, commitId: latestCommitId });
+    expect(fetched.data.id).toBe(latestCommitId);
+  });
+
+  testIfApi('lists commits including the new commit', async () => {
+    if (!latestCommitId) {
+      fail('Commit was not created in previous step');
+    }
+    const commits = await sdk.listCommits({ projectId, branchId: defaultBranch, limit: 5 });
+    const ids = commits.items.map((item) => item.id);
+    expect(ids).toContain(latestCommitId);
+  });
+});

--- a/tests/api/query.test.ts
+++ b/tests/api/query.test.ts
@@ -1,0 +1,57 @@
+import { beforeAll, afterAll, expect } from 'vitest';
+import { sdk } from './fixtures/sdk';
+import { describeIfApi, testIfApi } from './fixtures/test-helpers';
+import { createProjectParams } from './fixtures/project';
+import { requirementDefinitionFixture } from './fixtures/element';
+import { ensureLatestCommit } from './fixtures/commit';
+
+describeIfApi('Element query patterns', () => {
+  const projectParams = createProjectParams();
+  const elementFixture = requirementDefinitionFixture();
+
+  let projectId: string;
+  let commitId: string;
+  let elementId: string;
+
+  beforeAll(async () => {
+    const project = await sdk.createProject(projectParams);
+    projectId = project.data.id;
+
+    const latestCommit = await ensureLatestCommit(projectId, project.data.defaultBranch);
+    commitId = latestCommit.id;
+
+    const element = await sdk.createElement({ projectId, commitId, body: elementFixture.create });
+    elementId = element.data.id;
+  });
+
+  afterAll(async () => {
+    if (projectId) {
+      try {
+        await sdk.deleteProject({ projectId });
+      } catch (error) {
+        console.warn('Failed to delete test project', error);
+      }
+    }
+  });
+
+  testIfApi('supports cursor-based pagination', async () => {
+    const firstPage = await sdk.listElements({ projectId, commitId, limit: 1 });
+    expect(firstPage.items.length).toBeGreaterThanOrEqual(1);
+
+    if (firstPage.cursor) {
+      const secondPage = await sdk.listElements({ projectId, commitId, cursor: firstPage.cursor, limit: 1 });
+      expect(secondPage.items).toBeDefined();
+    }
+  });
+
+  testIfApi('filters elements by classifier id', async () => {
+    const filtered = await sdk.listElements({
+      projectId,
+      commitId,
+      classifierId: elementFixture.create.classifierId,
+    });
+
+    const ids = filtered.items.map((item) => item.id);
+    expect(ids).toContain(elementId);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals"],
+    "lib": ["ES2022", "DOM"],
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src", "tests", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/api/**/*.test.ts'],
+    testTimeout: 45000,
+    hookTimeout: 45000,
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration and tooling to run API-focused integration tests
- provide reusable fixtures for projects, elements, and commit bootstrap logic
- port cookbook scenarios into Vitest suites for project, element CRUD, and query workflows

## Testing
- not run (SysML API service is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e675f8c694832f9b0c20ac6a047174