### PR TITLE
Add Vue Monaco SysML editor with API diagnostics

### DIFF
--- a/apps/vue-monaco-editor/env.d.ts
+++ b/apps/vue-monaco-editor/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_VALIDATION_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/vue-monaco-editor/index.html
+++ b/apps/vue-monaco-editor/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SysML v2 Monaco Editor</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/vue-monaco-editor/src/App.vue
+++ b/apps/vue-monaco-editor/src/App.vue
@@ -1,0 +1,761 @@
+<template>
+  <div class="app-shell">
+    <header class="app-header">
+      <h1>SysML v2 Monaco Editor</h1>
+      <div class="spacer" />
+      <div class="control-group">
+        <label for="validation-endpoint">Validation endpoint</label>
+        <input
+          id="validation-endpoint"
+          v-model="validationEndpoint"
+          type="url"
+          placeholder="https://api.example.com/validation"
+          spellcheck="false"
+        />
+        <button type="button" @click="triggerValidation" :disabled="isValidating">
+          {{ isValidating ? 'Validating…' : 'Validate now' }}
+        </button>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <section class="editor-container">
+        <div ref="monacoRoot" class="monaco-container" />
+      </section>
+      <aside class="sidebar">
+        <section>
+          <div class="status-pill" :class="status">
+            <span class="dot">●</span>
+            <span>{{ statusMessage }}</span>
+          </div>
+          <p v-if="lastValidated" class="last-run">Last checked {{ lastValidated }}</p>
+        </section>
+        <section>
+          <h2>Diagnostics</h2>
+          <ul v-if="diagnostics.length" class="validation-list">
+            <li v-for="(issue, index) in diagnostics" :key="index" class="validation-item">
+              <h3>{{ severityLabel(issue.severity) }}</h3>
+              <p>{{ issue.message }}</p>
+              <span class="range">
+                Lines {{ issue.range.startLineNumber }}:{{ issue.range.startColumn }}
+                –
+                {{ issue.range.endLineNumber }}:{{ issue.range.endColumn }}
+              </span>
+              <div v-if="issue.elementId" class="range">Element ID · {{ issue.elementId }}</div>
+              <div class="quick-fix-badges">
+                <span v-for="(fix, idx) in badgeFixes(issue)" :key="idx">{{ fix }}</span>
+              </div>
+            </li>
+          </ul>
+          <p v-else>No diagnostics reported.</p>
+        </section>
+      </aside>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue';
+import loader from '@monaco-editor/loader';
+
+import type * as Monaco from 'monaco-editor';
+
+type MonacoApi = typeof import('monaco-editor');
+
+type ValidationState = 'idle' | 'running' | 'success' | 'error' | 'info';
+
+type IssueSeverity = 'error' | 'warning' | 'info';
+
+interface NormalizedRange {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+}
+
+interface NormalizedFix {
+  title: string;
+  replacementText?: string;
+  range?: NormalizedRange;
+}
+
+interface NormalizedIssue {
+  message: string;
+  severity: IssueSeverity;
+  range: NormalizedRange;
+  quickFixes: NormalizedFix[];
+  elementId?: string;
+}
+
+const defaultModel = `package Example::DriveUnit {
+  part controller : Controller { id = ctrl_controller; }
+  part motor : Motor { id = motor_primary; }
+
+  interface Controller {
+    id = ctrl_controller;
+    attribute torqueCommand : Real;
+    attribute desiredSpeed : Real;
+  }
+
+  interface Motor {
+    id = motor_primary;
+    attribute actualSpeed : Real;
+  }
+
+  requirement MaintainSpeed {
+    id = req_speed_limit;
+    constraint actualSpeed <= desiredSpeed;
+  }
+}`;
+
+const status = ref<ValidationState>('idle');
+const statusMessage = ref('Waiting for validation.');
+const diagnostics = ref<NormalizedIssue[]>([]);
+const lastValidatedAt = ref<Date | null>(null);
+
+const validationEndpoint = ref(
+  import.meta.env.VITE_VALIDATION_URL ?? 'http://localhost:9000/api/validation',
+);
+
+const monacoRoot = ref<HTMLDivElement | null>(null);
+const editorRef = shallowRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+
+const isValidating = computed(() => status.value === 'running');
+const lastValidated = computed(() =>
+  lastValidatedAt.value ? lastValidatedAt.value.toLocaleTimeString() : '',
+);
+
+let monacoApi: MonacoApi | null = null;
+let validationTimer: ReturnType<typeof setTimeout> | undefined;
+let modelDisposables: Monaco.IDisposable[] = [];
+let quickFixCommandId: string | null = null;
+let currentDiagnostics: NormalizedIssue[] = [];
+let idIndex = new Map<string, NormalizedRange>();
+
+onMounted(async () => {
+  loader.config({
+    paths: {
+      vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/min/vs',
+    },
+  });
+
+  monacoApi = await loader.init();
+  const monaco = monacoApi;
+
+  registerSysmlLanguage(monaco);
+
+  await nextTick();
+  if (!monacoRoot.value) {
+    return;
+  }
+
+  const editor = monaco.editor.create(monacoRoot.value, {
+    automaticLayout: true,
+    language: 'sysml',
+    theme: 'vs-dark',
+    value: defaultModel,
+    fontFamily: 'JetBrains Mono, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+    fontSize: 14,
+    minimap: { enabled: true },
+    wordWrap: 'on',
+    smoothScrolling: true,
+  });
+  editorRef.value = editor;
+
+  const model = editor.getModel();
+  if (!model) {
+    return;
+  }
+
+  quickFixCommandId = editor.addCommand(0, (_, label: string, detail: string) => {
+    status.value = 'info';
+    statusMessage.value = `Quick fix placeholder for "${label}"`;
+  });
+
+  modelDisposables.push(
+    model.onDidChangeContent(() => {
+      updateIdIndex(model.getValue());
+      scheduleValidation();
+    }),
+  );
+
+  registerLanguageProviders(monaco);
+
+  updateIdIndex(model.getValue());
+  scheduleValidation(true);
+});
+
+onBeforeUnmount(() => {
+  if (validationTimer) {
+    clearTimeout(validationTimer);
+  }
+  for (const disposable of modelDisposables) {
+    disposable.dispose();
+  }
+  modelDisposables = [];
+  const editor = editorRef.value;
+  if (editor) {
+    const model = editor.getModel();
+    if (model && monacoApi) {
+      monacoApi.editor.setModelMarkers(model, 'sysml-validation', []);
+    }
+    editor.dispose();
+    editorRef.value = null;
+  }
+});
+
+function scheduleValidation(immediate = false) {
+  if (!editorRef.value) {
+    return;
+  }
+
+  if (validationTimer) {
+    clearTimeout(validationTimer);
+  }
+
+  const run = () => {
+    const content = editorRef.value?.getValue() ?? '';
+    runValidation(content).catch((error) => {
+      console.error('Validation error', error);
+    });
+  };
+
+  if (immediate) {
+    run();
+  } else {
+    validationTimer = setTimeout(run, 600);
+  }
+}
+
+async function runValidation(content: string) {
+  if (!monacoApi || !editorRef.value) {
+    return;
+  }
+
+  if (!validationEndpoint.value) {
+    status.value = 'error';
+    statusMessage.value = 'Validation endpoint URL is required.';
+    clearMarkers();
+    diagnostics.value = [];
+    currentDiagnostics = [];
+    return;
+  }
+
+  status.value = 'running';
+  statusMessage.value = 'Sending model to validation service…';
+
+  try {
+    const response = await fetch(validationEndpoint.value, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Validation request failed with status ${response.status}`);
+    }
+
+    const payload = await safeJson(response);
+    const parsed = normalizeIssues(payload);
+    currentDiagnostics = parsed;
+    diagnostics.value = parsed;
+    applyMarkers(parsed);
+
+    lastValidatedAt.value = new Date();
+    if (parsed.length === 0) {
+      status.value = 'success';
+      statusMessage.value = 'No diagnostics returned by the service.';
+    } else {
+      status.value = 'info';
+      statusMessage.value = `${parsed.length} diagnostic${parsed.length === 1 ? '' : 's'} reported.`;
+    }
+  } catch (error) {
+    currentDiagnostics = [];
+    diagnostics.value = [];
+    clearMarkers();
+    status.value = 'error';
+    statusMessage.value = error instanceof Error ? error.message : 'Validation failed.';
+  }
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.warn('Validation response was not JSON', error);
+    return null;
+  }
+}
+
+function applyMarkers(issues: NormalizedIssue[]) {
+  if (!monacoApi || !editorRef.value) {
+    return;
+  }
+  const model = editorRef.value.getModel();
+  if (!model) {
+    return;
+  }
+
+  const markers = issues.map((issue) => ({
+    severity: toMarkerSeverity(monacoApi!, issue.severity),
+    message: issue.message,
+    startLineNumber: issue.range.startLineNumber,
+    startColumn: issue.range.startColumn,
+    endLineNumber: issue.range.endLineNumber,
+    endColumn: issue.range.endColumn,
+    tags: issue.quickFixes.length ? [monacoApi!.MarkerTag.Unnecessary] : undefined,
+    relatedInformation: issue.elementId
+      ? [
+          {
+            resource: model.uri,
+            message: `Element ${issue.elementId}`,
+            startLineNumber: issue.range.startLineNumber,
+            startColumn: issue.range.startColumn,
+            endLineNumber: issue.range.endLineNumber,
+            endColumn: issue.range.endColumn,
+          },
+        ]
+      : undefined,
+  }));
+
+  monacoApi.editor.setModelMarkers(model, 'sysml-validation', markers);
+}
+
+function clearMarkers() {
+  if (!monacoApi || !editorRef.value) {
+    return;
+  }
+  const model = editorRef.value.getModel();
+  if (model) {
+    monacoApi.editor.setModelMarkers(model, 'sysml-validation', []);
+  }
+}
+
+function registerSysmlLanguage(monaco: MonacoApi) {
+  monaco.languages.register({ id: 'sysml' });
+  monaco.languages.setLanguageConfiguration('sysml', {
+    comments: {
+      lineComment: '--',
+      blockComment: ['/*', '*/'],
+    },
+    brackets: [
+      ['{', '}'],
+      ['[', ']'],
+      ['(', ')'],
+    ],
+    autoClosingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '(', close: ')' },
+      { open: '"', close: '"', notIn: ['string'] },
+      { open: "'", close: "'", notIn: ['string'] },
+    ],
+    surroundingPairs: [
+      { open: '{', close: '}' },
+      { open: '"', close: '"' },
+      { open: '(', close: ')' },
+    ],
+  });
+
+  monaco.languages.setMonarchTokensProvider('sysml', {
+    keywords: [
+      'package',
+      'import',
+      'part',
+      'interface',
+      'requirement',
+      'constraint',
+      'state',
+      'transition',
+      'action',
+      'attribute',
+      'behavior',
+      'subject',
+      'view',
+      'viewpoint',
+      'usage',
+      'occurrence',
+      'end',
+    ],
+    operators: ['=', '::', ':', ';'],
+    symbols: /[=><!~?:&|+\-*\/%^]+/,
+    tokenizer: {
+      root: [
+        [/[a-zA-Z_][\w\-]*/, {
+          cases: {
+            '@keywords': 'keyword',
+            '@default': 'identifier',
+          },
+        }],
+        { include: '@whitespace' },
+        [/[{}()[\]]/, '@brackets'],
+        [/\d+(\.\d+)?/, 'number'],
+        [/"([^"\\]|\\.)*"/, 'string'],
+        [/\-\-.*$/, 'comment'],
+      ],
+      whitespace: [[/[\s]+/, 'white']],
+    },
+  });
+}
+
+function registerLanguageProviders(monaco: MonacoApi) {
+  modelDisposables.push(
+    monaco.languages.registerCodeActionProvider('sysml', {
+      provideCodeActions(model, range, context) {
+        const actions: Monaco.languages.CodeAction[] = [];
+        for (const issue of currentDiagnostics) {
+          const issueRange = toMonacoRange(issue.range, monaco);
+          if (!monaco.Range.areIntersecting(issueRange, range)) {
+            continue;
+          }
+
+          const markers = context.markers
+            .filter((marker) =>
+              monaco.Range.areIntersecting(
+                issueRange,
+                new monaco.Range(
+                  marker.startLineNumber,
+                  marker.startColumn,
+                  marker.endLineNumber,
+                  marker.endColumn,
+                ),
+              ),
+            )
+            .map((marker) => ({ ...marker }));
+
+          const fixes = issue.quickFixes.length
+            ? issue.quickFixes
+            : [
+                {
+                  title: 'Review issue in validation service',
+                },
+              ];
+
+          for (let idx = 0; idx < fixes.length; idx += 1) {
+            const fix = fixes[idx];
+            const editRange = toMonacoRange(fix.range ?? issue.range, monaco);
+            const edit =
+              typeof fix.replacementText === 'string'
+                ? {
+                    edits: [
+                      {
+                        resource: model.uri,
+                        edit: {
+                          range: editRange,
+                          text: fix.replacementText,
+                        },
+                      },
+                    ],
+                  }
+                : undefined;
+
+            actions.push({
+              title: fix.title,
+              kind: monaco.languages.CodeActionKind.QuickFix,
+              diagnostics: markers,
+              edit,
+              command:
+                !edit && quickFixCommandId
+                  ? {
+                      id: quickFixCommandId,
+                      title: fix.title,
+                      arguments: [fix.title, issue.message],
+                    }
+                  : undefined,
+              isPreferred: idx === 0,
+            });
+          }
+        }
+
+        return {
+          actions,
+          dispose: () => undefined,
+        };
+      },
+      providedCodeActionKinds: [monaco.languages.CodeActionKind.QuickFix],
+    }),
+  );
+
+  modelDisposables.push(
+    monaco.languages.registerDefinitionProvider('sysml', {
+      provideDefinition(model, position) {
+        const word = model.getWordAtPosition(position);
+        if (!word) {
+          return null;
+        }
+        const range = idIndex.get(word.word);
+        if (!range) {
+          return null;
+        }
+        return {
+          uri: model.uri,
+          range: toMonacoRange(range, monaco),
+        };
+      },
+    }),
+  );
+
+  modelDisposables.push(
+    monaco.languages.registerHoverProvider('sysml', {
+      provideHover(model, position) {
+        const word = model.getWordAtPosition(position);
+        if (!word) {
+          return null;
+        }
+        const range = idIndex.get(word.word);
+        if (!range) {
+          return null;
+        }
+        const related = currentDiagnostics.filter((issue) => issue.elementId === word.word);
+        const lines: Monaco.IMarkdownString[] = [
+          { value: `**Element ID**\\n\\n\`${word.word}\`` },
+        ];
+        if (related.length) {
+          lines.push({
+            value: related
+              .map((issue) => `• ${issue.message}`)
+              .join('\n'),
+          });
+        }
+        return {
+          range: toMonacoRange(range, monaco),
+          contents: lines,
+        };
+      },
+    }),
+  );
+}
+
+function toMonacoRange(range: NormalizedRange, monaco: MonacoApi) {
+  return new monaco.Range(
+    range.startLineNumber,
+    range.startColumn,
+    range.endLineNumber,
+    range.endColumn,
+  );
+}
+
+function updateIdIndex(content: string) {
+  const pattern = /\b(?:id|elementId)\s*[:=]\s*("?)([A-Za-z_][\w.\-]*)\1/g;
+  const lines = content.split(/\r?\n/);
+  const nextIndex = new Map<string, NormalizedRange>();
+
+  for (let lineNo = 0; lineNo < lines.length; lineNo += 1) {
+    const line = lines[lineNo];
+    let match: RegExpExecArray | null;
+    // eslint-disable-next-line no-cond-assign
+    while ((match = pattern.exec(line)) !== null) {
+      const identifier = match[2];
+      const offset = match.index + match[0].indexOf(identifier);
+      const startColumn = offset + 1;
+      nextIndex.set(identifier, {
+        startLineNumber: lineNo + 1,
+        startColumn,
+        endLineNumber: lineNo + 1,
+        endColumn: startColumn + identifier.length,
+      });
+    }
+  }
+
+  idIndex = nextIndex;
+}
+
+function normalizeIssues(payload: unknown): NormalizedIssue[] {
+  const list = extractIssueList(payload);
+  const normalized: NormalizedIssue[] = [];
+  for (const raw of list) {
+    const issue = normalizeIssue(raw);
+    if (issue) {
+      normalized.push(issue);
+    }
+  }
+  return normalized;
+}
+
+function extractIssueList(value: unknown): unknown[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === 'object') {
+    const container = value as Record<string, unknown>;
+    for (const key of ['issues', 'diagnostics', 'results', 'messages']) {
+      const candidate = container[key];
+      if (Array.isArray(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return [];
+}
+
+function normalizeIssue(value: unknown): NormalizedIssue | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  const source = value as Record<string, unknown>;
+  const message = firstString(source.message, source.detail, source.description, source.text);
+  if (!message) {
+    return undefined;
+  }
+  const severity = normalizeSeverity(source.severity, source.level, source.type);
+  const range = normalizeRange(source.range ?? source.span ?? source.location ?? source, message);
+  const quickFixes = normalizeFixes(source.quickFixes ?? source.fixes ?? source.actions);
+  const elementId = firstString(source.elementId, source.elementID, source.id, source.identifier);
+  return { message, severity, range, quickFixes, elementId: elementId ?? undefined };
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeSeverity(...candidates: unknown[]): IssueSeverity {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const normalized = candidate.toLowerCase();
+      if (normalized.includes('warn')) {
+        return 'warning';
+      }
+      if (normalized.includes('info')) {
+        return 'info';
+      }
+      if (normalized.includes('error') || normalized.includes('fatal')) {
+        return 'error';
+      }
+    }
+    if (typeof candidate === 'number' && !Number.isNaN(candidate)) {
+      if (candidate <= 1) {
+        return 'error';
+      }
+      if (candidate === 2) {
+        return 'warning';
+      }
+      if (candidate >= 3) {
+        return 'info';
+      }
+    }
+  }
+  return 'error';
+}
+
+function normalizeRange(raw: unknown, fallback: string): NormalizedRange {
+  const object = (typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {}) as Record<
+    string,
+    unknown
+  >;
+
+  const startLine = coerceNumber(
+    object.startLine ?? object.start?.line ?? object.line ?? object.lineNumber,
+    1,
+  );
+  const startColumn = coerceNumber(
+    object.startColumn ?? object.start?.column ?? object.column ?? object.character ?? object.offset,
+    1,
+  );
+
+  let endLine = coerceNumber(
+    object.endLine ?? object.end?.line ?? object.toLine ?? object.lineEnd,
+    startLine,
+  );
+  let endColumn = coerceNumber(
+    object.endColumn ?? object.end?.column ?? object.toColumn ?? object.columnEnd ?? object.length,
+    startColumn + Math.max(1, fallback.length),
+  );
+
+  if (typeof object.length === 'number' && !Number.isNaN(object.length)) {
+    const length = Math.max(1, Math.floor(object.length));
+    endLine = startLine;
+    endColumn = startColumn + length;
+  }
+
+  if (endLine < startLine || (endLine === startLine && endColumn <= startColumn)) {
+    endLine = startLine;
+    endColumn = startColumn + Math.max(1, fallback.length);
+  }
+
+  return {
+    startLineNumber: startLine,
+    startColumn,
+    endLineNumber: endLine,
+    endColumn,
+  };
+}
+
+function coerceNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(1, Math.floor(value));
+  }
+  return Math.max(1, Math.floor(fallback));
+}
+
+function normalizeFixes(raw: unknown): NormalizedFix[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const fixes: NormalizedFix[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const data = entry as Record<string, unknown>;
+    const title = firstString(data.title, data.label, data.name);
+    if (!title) {
+      continue;
+    }
+    const replacementText = firstString(data.replacement, data.text, data.insert, data.editText);
+    const rangeSource = data.range ?? data.location ?? data.span;
+    const range = rangeSource ? normalizeRange(rangeSource, title) : undefined;
+    fixes.push({ title, replacementText, range });
+  }
+  return fixes;
+}
+
+function toMarkerSeverity(monaco: MonacoApi, severity: IssueSeverity) {
+  switch (severity) {
+    case 'warning':
+      return monaco.MarkerSeverity.Warning;
+    case 'info':
+      return monaco.MarkerSeverity.Info;
+    default:
+      return monaco.MarkerSeverity.Error;
+  }
+}
+
+function badgeFixes(issue: NormalizedIssue): string[] {
+  if (issue.quickFixes.length === 0) {
+    return ['Quick fix available on hover'];
+  }
+  return issue.quickFixes.map((fix) => fix.title);
+}
+
+function severityLabel(severity: IssueSeverity) {
+  switch (severity) {
+    case 'warning':
+      return 'Warning';
+    case 'info':
+      return 'Information';
+    default:
+      return 'Error';
+  }
+}
+
+function triggerValidation() {
+  if (!editorRef.value) {
+    return;
+  }
+  scheduleValidation(true);
+}
+</script>

--- a/apps/vue-monaco-editor/src/main.ts
+++ b/apps/vue-monaco-editor/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './style.css';
+
+createApp(App).mount('#app');

--- a/apps/vue-monaco-editor/src/style.css
+++ b/apps/vue-monaco-editor/src/style.css
@@ -1,0 +1,211 @@
+:root {
+  color-scheme: dark light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.app-header h1 {
+  font-size: 1.125rem;
+  margin: 0;
+  font-weight: 600;
+}
+
+.app-header .spacer {
+  flex: 1 1 auto;
+}
+
+.control-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.control-group label {
+  font-size: 0.875rem;
+  opacity: 0.85;
+}
+
+.control-group input {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  min-width: 18rem;
+  color: inherit;
+}
+
+.control-group button {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  background: rgba(30, 41, 59, 0.8);
+  color: inherit;
+  cursor: pointer;
+}
+
+.control-group button:hover {
+  background: rgba(51, 65, 85, 0.9);
+}
+
+.main-content {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  min-height: 0;
+}
+
+.editor-container {
+  position: relative;
+  min-height: 0;
+}
+
+.editor-container .monaco-container {
+  position: absolute;
+  inset: 0;
+}
+
+.sidebar {
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.sidebar section {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+}
+
+.status-pill .dot {
+  font-size: 0.625rem;
+}
+
+.status-pill.info {
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+}
+
+.status-pill.success {
+  background: rgba(34, 197, 94, 0.2);
+  color: #bbf7d0;
+}
+
+.status-pill.error {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+}
+
+.status-pill.idle {
+  background: rgba(148, 163, 184, 0.15);
+  color: #cbd5f5;
+}
+
+.status-pill.running {
+  background: rgba(251, 191, 36, 0.2);
+  color: #fde68a;
+}
+
+.validation-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.validation-item {
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+}
+
+.validation-item h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+.validation-item p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.validation-item .range {
+  display: block;
+  font-size: 0.75rem;
+  opacity: 0.7;
+  margin-top: 0.35rem;
+}
+
+.last-run {
+  margin: 0.75rem 0 0;
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.quick-fix-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.quick-fix-badges span {
+  background: rgba(59, 130, 246, 0.2);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+}
+
+@media (max-width: 1080px) {
+  .main-content {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    border-left: none;
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
+  }
+}

--- a/apps/vue-monaco-editor/tsconfig.json
+++ b/apps/vue-monaco-editor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src", "./vite.config.ts", "./env.d.ts"],
+  "compilerOptions": {
+    "composite": false,
+    "types": ["vite/client"]
+  }
+}

--- a/apps/vue-monaco-editor/vite.config.ts
+++ b/apps/vue-monaco-editor/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [vue()],
+  server: {
+    host: '0.0.0.0',
+    port: 4173,
+  },
+  preview: {
+    host: '0.0.0.0',
+    port: 4173,
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,11 +6,21 @@
   "type": "module",
   "scripts": {
     "build": "echo 'TypeScript sources only \u2013 no build step configured.'",
-    "test": "vitest run"
+    "test": "vitest run",
+    "dev:editor": "vite --config apps/vue-monaco-editor/vite.config.ts",
+    "build:editor": "vite build --config apps/vue-monaco-editor/vite.config.ts",
+    "preview:editor": "vite preview --config apps/vue-monaco-editor/vite.config.ts"
+  },
+  "dependencies": {
+    "@monaco-editor/loader": "^1.4.0",
+    "monaco-editor": "^0.47.0",
+    "vue": "^3.4.37"
   },
   "devDependencies": {
     "@types/node": "^20.16.3",
+    "@vitejs/plugin-vue": "^5.0.5",
     "typescript": "^5.5.4",
+    "vite": "^5.3.4",
     "vitest": "^1.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a Vite-powered Vue + Monaco editor that registers a SysML language, polls the API validation endpoint, and surfaces diagnostics with quick-fix placeholders
- surface go-to-definition and hover support driven by element identifiers while rendering an inline diagnostics panel
- wire new tooling scripts, dependencies, and TypeScript definitions needed to run the editor

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e67860d704832fa051f870e2acf094