### PR TITLE
Add SysML block graph mapping and layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "echo 'TypeScript sources only \u2013 no build step configured.'",
     "test": "vitest run"
   },
+  "dependencies": {
+    "elkjs": "^0.8.2"
+  },
   "devDependencies": {
     "@types/node": "^20.16.3",
     "typescript": "^5.5.4",

--- a/src/graph/block-graph.ts
+++ b/src/graph/block-graph.ts
@@ -1,0 +1,560 @@
+import type { ElementRecord } from '../generated/types';
+import {
+  type BlockConnectorGraph,
+  type GraphEdge,
+  type GraphEndpoint,
+  type GraphNode,
+  type GraphPort,
+  type GraphPortKind,
+  type SysMLElement,
+  type TextLocation,
+  type TextPosition,
+} from './types';
+
+export interface BuildBlockConnectorGraphOptions {
+  filter?: (record: ElementRecord) => boolean;
+}
+
+export function buildBlockConnectorGraph(
+  elements: ElementRecord[],
+  options: BuildBlockConnectorGraphOptions = {},
+): BlockConnectorGraph {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  const featureIndex = new Map<string, GraphEndpoint>();
+  const connectors: Array<{ connector: SysMLElement; parentNodeId: string }> = [];
+  const processedConnectorIds = new Set<string>();
+  let generatedIdCounter = 0;
+
+  const generateId = (prefix: string): string => {
+    generatedIdCounter += 1;
+    return `${prefix}-${generatedIdCounter}`;
+  };
+
+  for (const record of elements) {
+    if (options.filter && !options.filter(record)) {
+      continue;
+    }
+
+    const payload = record.payload;
+    if (!isRecord(payload) || !isBlock(payload)) {
+      continue;
+    }
+
+    const elementId = getElementId(payload, record.id || generateId('block'));
+    const node: GraphNode = {
+      id: elementId,
+      elementId,
+      label: getDeclaredName(payload) ?? record.name ?? elementId,
+      kind: 'block',
+      documentation: getString(payload['documentation']) ?? record.documentation,
+      textLocation: extractTextLocation(payload),
+      ports: [],
+      raw: payload,
+      record,
+    };
+
+    const relationships = toArray(payload['ownedRelationship']);
+    for (const relationshipRaw of relationships) {
+      if (!isRecord(relationshipRaw)) {
+        continue;
+      }
+
+      if (isPart(relationshipRaw) || isPort(relationshipRaw)) {
+        collectFeaturePorts({
+          node,
+          feature: relationshipRaw,
+          featureIndex,
+          generateId,
+        });
+      } else if (isConnector(relationshipRaw)) {
+        connectors.push({ connector: relationshipRaw, parentNodeId: node.id });
+      }
+
+      const members = collectRelationshipMembers(relationshipRaw);
+      for (const member of members) {
+        if (isPart(member) || isPort(member)) {
+          collectFeaturePorts({
+            node,
+            feature: member,
+            featureIndex,
+            generateId,
+          });
+        } else if (isConnector(member)) {
+          connectors.push({ connector: member, parentNodeId: node.id });
+        }
+      }
+    }
+
+    nodes.push(node);
+  }
+
+  const elementIdToNodeId = new Map(nodes.map((node) => [node.elementId, node.id]));
+  for (const node of nodes) {
+    for (const port of node.ports) {
+      if (port.typeRef) {
+        port.targetNodeId = elementIdToNodeId.get(port.typeRef);
+      }
+    }
+  }
+
+  for (const { connector, parentNodeId } of connectors) {
+    const connectorId = getElementId(connector, generateId(`${parentNodeId}#connector`));
+    if (processedConnectorIds.has(connectorId)) {
+      continue;
+    }
+    processedConnectorIds.add(connectorId);
+
+    const endFeatureIds = unique(collectConnectorEndFeatureIds(connector));
+    if (endFeatureIds.length < 2) {
+      continue;
+    }
+
+    const label = getDeclaredName(connector);
+    const textLocation = extractTextLocation(connector);
+
+    const [firstEnd, ...rest] = endFeatureIds;
+    const firstEndpoint = firstEnd ? featureIndex.get(firstEnd) : undefined;
+    if (!firstEndpoint) {
+      continue;
+    }
+
+    rest.forEach((featureId, index) => {
+      if (!featureId) {
+        return;
+      }
+      const endpoint = featureIndex.get(featureId);
+      if (!endpoint) {
+        return;
+      }
+      const edgeId = index === 0 ? connectorId : `${connectorId}::${index}`;
+      edges.push({
+        id: edgeId,
+        connectorId,
+        label,
+        source: { ...firstEndpoint },
+        target: { ...endpoint },
+        textLocation,
+        raw: connector,
+      });
+    });
+  }
+
+  nodes.sort((a, b) => a.label.localeCompare(b.label));
+  for (const node of nodes) {
+    node.ports.sort((a, b) => a.label.localeCompare(b.label));
+  }
+  edges.sort((a, b) => a.id.localeCompare(b.id));
+
+  return { nodes, edges };
+}
+
+interface CollectFeaturePortsParams {
+  node: GraphNode;
+  feature: SysMLElement;
+  featureIndex: Map<string, GraphEndpoint>;
+  generateId: (prefix: string) => string;
+  context?: PortContext;
+}
+
+interface PortContext {
+  parentFeatureId?: string;
+  parentLabel?: string;
+}
+
+function collectFeaturePorts({
+  node,
+  feature,
+  featureIndex,
+  generateId,
+  context,
+}: CollectFeaturePortsParams): void {
+  if (isPart(feature)) {
+    const partPort = createPort({
+      node,
+      feature,
+      kind: 'part',
+      generateId,
+      context,
+    });
+    addPort(node, partPort, featureIndex);
+
+    const nestedRelationships = toArray(feature['ownedRelationship']);
+    for (const nested of nestedRelationships) {
+      if (!isRecord(nested)) {
+        continue;
+      }
+
+      if (isPort(nested)) {
+        collectFeaturePorts({
+          node,
+          feature: nested,
+          featureIndex,
+          generateId,
+          context: {
+            parentFeatureId: partPort.featureId,
+            parentLabel: partPort.label,
+          },
+        });
+      }
+
+      const nestedMembers = collectRelationshipMembers(nested);
+      for (const nestedMember of nestedMembers) {
+        if (isPort(nestedMember)) {
+          collectFeaturePorts({
+            node,
+            feature: nestedMember,
+            featureIndex,
+            generateId,
+            context: {
+              parentFeatureId: partPort.featureId,
+              parentLabel: partPort.label,
+            },
+          });
+        }
+      }
+    }
+  } else if (isPort(feature)) {
+    const port = createPort({
+      node,
+      feature,
+      kind: 'port',
+      generateId,
+      context,
+    });
+    addPort(node, port, featureIndex);
+  }
+}
+
+interface CreatePortParams {
+  node: GraphNode;
+  feature: SysMLElement;
+  kind: GraphPortKind;
+  generateId: (prefix: string) => string;
+  context?: PortContext;
+}
+
+function createPort({ node, feature, kind, generateId, context }: CreatePortParams): GraphPort {
+  const featureId = getElementId(feature, generateId(`${node.id}#${kind}`));
+  const name = getDeclaredName(feature) ?? featureId;
+  const label = context?.parentLabel ? `${context.parentLabel}.${name}` : name;
+  const typeRef =
+    getReferenceId(feature['type']) ??
+    getReferenceId(feature['definition']) ??
+    getReferenceId(feature['declaredType']) ??
+    getReferenceId(feature['classifier']) ??
+    getReferenceId(feature['referencedFeature']) ??
+    getReferenceId(feature['referencedElement']) ??
+    getReferenceId(feature['typeRef']);
+
+  return {
+    id: featureId,
+    featureId,
+    kind,
+    label,
+    typeRef,
+    parentFeatureId: context?.parentFeatureId,
+    textLocation: extractTextLocation(feature),
+    raw: feature,
+  };
+}
+
+function addPort(node: GraphNode, port: GraphPort, featureIndex: Map<string, GraphEndpoint>): void {
+  if (featureIndex.has(port.featureId)) {
+    return;
+  }
+  node.ports.push(port);
+  featureIndex.set(port.featureId, {
+    nodeId: node.id,
+    portId: port.id,
+    featureId: port.featureId,
+  });
+}
+
+function collectRelationshipMembers(relationship: SysMLElement): SysMLElement[] {
+  const keys = [
+    'ownedMember',
+    'member',
+    'ownedRelatedElement',
+    'relatedElement',
+    'ownedEnd',
+    'ownedParticipant',
+    'participant',
+    'ownedConnectorEnd',
+    'ownedMemberEnd',
+    'ownedFeature',
+    'feature',
+  ];
+
+  const members: SysMLElement[] = [];
+  for (const key of keys) {
+    const value = relationship[key];
+    if (value === undefined) {
+      continue;
+    }
+    for (const candidate of flattenElements(value)) {
+      members.push(candidate);
+    }
+  }
+  return members;
+}
+
+function collectConnectorEndFeatureIds(connector: SysMLElement): Array<string | undefined> {
+  const featureIds: Array<string | undefined> = [];
+
+  const relationships = toArray(connector['ownedRelationship']);
+  for (const relationship of relationships) {
+    if (!isRecord(relationship)) {
+      continue;
+    }
+
+    if (isConnectorEnd(relationship)) {
+      featureIds.push(getConnectorEndFeatureId(relationship));
+    }
+
+    const members = collectRelationshipMembers(relationship);
+    for (const member of members) {
+      if (isConnectorEnd(member)) {
+        featureIds.push(getConnectorEndFeatureId(member));
+      }
+    }
+  }
+
+  const directKeys = ['ends', 'end', 'connectorEnd', 'ownedEnd', 'ownedConnectorEnd'];
+  for (const key of directKeys) {
+    const value = connector[key];
+    if (value === undefined) {
+      continue;
+    }
+    for (const candidate of flattenElements(value)) {
+      if (isConnectorEnd(candidate)) {
+        featureIds.push(getConnectorEndFeatureId(candidate));
+      }
+    }
+  }
+
+  return featureIds;
+}
+
+function getConnectorEndFeatureId(end: SysMLElement): string | undefined {
+  const candidates = [
+    end['connectedFeature'],
+    end['memberEnd'],
+    end['feature'],
+    end['role'],
+    end['target'],
+    end['source'],
+    end['participant'],
+  ];
+
+  for (const candidate of candidates) {
+    const referenceId = getReferenceId(candidate);
+    if (referenceId) {
+      return referenceId;
+    }
+  }
+
+  return undefined;
+}
+
+function getElementId(element: SysMLElement, fallback: string): string {
+  return getString(element['@id']) ?? getString(element['id']) ?? fallback;
+}
+
+function getDeclaredName(element: SysMLElement): string | undefined {
+  return getString(element['declaredName']) ?? getString(element['name']);
+}
+
+function getType(element: SysMLElement): string | undefined {
+  const rawType = element['@type'] ?? element['type'];
+  if (Array.isArray(rawType)) {
+    for (const value of rawType) {
+      if (typeof value === 'string') {
+        return value;
+      }
+    }
+    return undefined;
+  }
+  return typeof rawType === 'string' ? rawType : undefined;
+}
+
+function isBlock(element: SysMLElement): boolean {
+  const type = getType(element);
+  return Boolean(type && /Block(Definition|Usage)?$/i.test(type));
+}
+
+function isPart(element: SysMLElement): boolean {
+  const type = getType(element);
+  return Boolean(type && /Part(Definition|Usage)$/i.test(type));
+}
+
+function isPort(element: SysMLElement): boolean {
+  const type = getType(element);
+  return Boolean(type && /Port(Definition|Usage)$/i.test(type));
+}
+
+function isConnector(element: SysMLElement): boolean {
+  const type = getType(element);
+  return Boolean(type && /Connector(Definition|Usage)?$/i.test(type));
+}
+
+function isConnectorEnd(element: SysMLElement): boolean {
+  const type = getType(element);
+  if (type && /ConnectorEnd$/i.test(type)) {
+    return true;
+  }
+  return (
+    element['connectedFeature'] !== undefined ||
+    element['memberEnd'] !== undefined ||
+    element['feature'] !== undefined ||
+    element['participant'] !== undefined
+  );
+}
+
+function extractTextLocation(element: SysMLElement): TextLocation | undefined {
+  const candidates: unknown[] = [
+    element['textLocation'],
+    element['sourceLocation'],
+    element['source'],
+    getNested(element, ['metadata', 'textLocation']),
+    getNested(element, ['metadata', 'source']),
+    getNested(element, ['@metadata', 'textLocation']),
+    getNested(element, ['@metadata', 'source']),
+  ];
+
+  for (const candidate of candidates) {
+    const location = parseTextLocation(candidate);
+    if (location) {
+      return location;
+    }
+  }
+
+  return undefined;
+}
+
+function parseTextLocation(value: unknown): TextLocation | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const uri = getString(value['uri']) ?? getString(value['path']) ?? getString(value['source']);
+  if (!uri) {
+    return undefined;
+  }
+
+  const rangeValue = value['range'];
+  let start: TextPosition | undefined;
+  let end: TextPosition | undefined;
+
+  if (isRecord(rangeValue)) {
+    start = parseTextPosition(rangeValue['start'] ?? rangeValue['from']);
+    end = parseTextPosition(rangeValue['end'] ?? rangeValue['to']);
+  }
+
+  if (!start) {
+    start = parseTextPosition(value['start']);
+  }
+  if (!end) {
+    end = parseTextPosition(value['end']);
+  }
+
+  if (start && !end) {
+    end = start;
+  }
+  if (end && !start) {
+    start = end;
+  }
+
+  const range = start && end ? { start, end } : undefined;
+  return { uri, range };
+}
+
+function parseTextPosition(value: unknown): TextPosition | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const line = getNumber(value['line']);
+  const column = getNumber(value['column']);
+  if (line === undefined || column === undefined) {
+    return undefined;
+  }
+  const offset = getNumber(value['offset']);
+  return offset === undefined ? { line, column } : { line, column, offset };
+}
+
+function getNested(element: SysMLElement, path: string[]): unknown {
+  let current: unknown = element;
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+function getReferenceId(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const candidate of value) {
+      const result = getReferenceId(candidate);
+      if (result) {
+        return result;
+      }
+    }
+    return undefined;
+  }
+  if (isRecord(value)) {
+    return (
+      getString(value['@id']) ??
+      getString(value['id']) ??
+      getReferenceId(value['element']) ??
+      getReferenceId(value['referencedElement']) ??
+      getReferenceId(value['feature']) ??
+      getReferenceId(value['value']) ??
+      getReferenceId(value['type'])
+    );
+  }
+  return undefined;
+}
+
+function unique<T>(values: T[]): T[] {
+  const seen = new Set<T>();
+  const result: T[] = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+function flattenElements(value: unknown): SysMLElement[] {
+  return toArray(value).filter(isRecord);
+}
+
+function toArray<T>(value: T | T[] | undefined): T[];
+function toArray<T>(value: T | T[] | undefined | null): T[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [value];
+}
+
+function isRecord(value: unknown): value is SysMLElement {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}

--- a/src/graph/elk-layout.ts
+++ b/src/graph/elk-layout.ts
@@ -1,0 +1,185 @@
+import ELK from 'elkjs/lib/elk.bundled.js';
+import type { ElkExtendedEdge, ElkLabel, ElkNode, ElkPoint, ElkPort } from 'elkjs';
+import type {
+  BlockConnectorGraph,
+  GraphPort,
+  GraphLayout,
+  LayoutConfig,
+  LayoutEdge,
+  LayoutLabel,
+  LayoutNode,
+  LayoutPoint,
+  LayoutPort,
+} from './types';
+
+const DEFAULT_NODE_SIZE = { width: 220, height: 140 } as const;
+const DEFAULT_PORT_SIZE = { width: 16, height: 16 } as const;
+const DEFAULT_SPACING = {
+  nodeNode: 80,
+  edgeEdge: 40,
+  nodeNodeBetweenLayers: 100,
+} as const;
+
+export async function layoutBlockConnectorGraph(
+  graph: BlockConnectorGraph,
+  config: LayoutConfig = {},
+): Promise<GraphLayout> {
+  const elk = new ELK();
+
+  const nodeSize = config.nodeSize ?? DEFAULT_NODE_SIZE;
+  const portSize = config.portSize ?? DEFAULT_PORT_SIZE;
+  const spacing = {
+    nodeNode: config.spacing?.nodeNode ?? DEFAULT_SPACING.nodeNode,
+    edgeEdge: config.spacing?.edgeEdge ?? DEFAULT_SPACING.edgeEdge,
+    nodeNodeBetweenLayers:
+      config.spacing?.nodeNodeBetweenLayers ?? DEFAULT_SPACING.nodeNodeBetweenLayers,
+  };
+  const direction = config.direction ?? 'RIGHT';
+
+  const elkGraph = {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'layered',
+      'elk.direction': direction,
+      'elk.portConstraints': 'FIXED_SIDE',
+      'elk.spacing.nodeNode': spacing.nodeNode.toString(),
+      'elk.spacing.edgeEdge': spacing.edgeEdge.toString(),
+      'elk.spacing.nodeNodeBetweenLayers': spacing.nodeNodeBetweenLayers.toString(),
+      'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+      'elk.edgeRouting': 'ORTHOGONAL',
+      ...config.layoutOptions,
+    },
+    children: graph.nodes.map((node) => ({
+      id: node.id,
+      width: nodeSize.width,
+      height: nodeSize.height,
+      layoutOptions: {
+        portConstraints: 'FIXED_SIDE',
+      },
+      labels: node.label
+        ? [
+            {
+              id: `${node.id}::label`,
+              text: node.label,
+            },
+          ]
+        : undefined,
+      ports: node.ports.map((port) => ({
+        id: port.id,
+        width: portSize.width,
+        height: portSize.height,
+        properties: {
+          'port.side': resolvePortSide(port.parentFeatureId, port.kind),
+        },
+        labels: port.label
+          ? [
+              {
+                id: `${port.id}::label`,
+                text: port.label,
+              },
+            ]
+          : undefined,
+      })),
+    })),
+    edges: graph.edges.map((edge) => ({
+      id: edge.id,
+      sources: [`${edge.source.nodeId}/${edge.source.portId}`],
+      targets: [`${edge.target.nodeId}/${edge.target.portId}`],
+      labels: edge.label
+        ? [
+            {
+              id: `${edge.id}::label`,
+              text: edge.label,
+            },
+          ]
+        : undefined,
+    })),
+  };
+
+  const layout = await elk.layout(elkGraph);
+  return convertLayout(layout);
+}
+
+function resolvePortSide(parentFeatureId: string | undefined, kind: GraphPort['kind']): string {
+  if (parentFeatureId) {
+    return 'SOUTH';
+  }
+  return kind === 'part' ? 'WEST' : 'EAST';
+}
+
+function convertLayout(root: ElkNode): GraphLayout {
+  const nodes: Record<string, LayoutNode> = {};
+  for (const child of root.children ?? []) {
+    collectNodeLayouts(child, nodes);
+  }
+
+  const edges: Record<string, LayoutEdge> = {};
+  for (const edge of root.edges ?? []) {
+    edges[edge.id] = convertEdge(edge);
+  }
+
+  return { nodes, edges };
+}
+
+function collectNodeLayouts(node: ElkNode, target: Record<string, LayoutNode>): void {
+  const labels = (node.labels ?? []).map(convertLabel);
+  const ports: Record<string, LayoutPort> = {};
+  for (const port of node.ports ?? []) {
+    ports[port.id] = convertPort(port, node);
+  }
+
+  target[node.id] = {
+    x: node.x ?? 0,
+    y: node.y ?? 0,
+    width: node.width ?? 0,
+    height: node.height ?? 0,
+    labels,
+    ports,
+  };
+
+  for (const child of node.children ?? []) {
+    collectNodeLayouts(child, target);
+  }
+}
+
+function convertLabel(label: ElkLabel): LayoutLabel {
+  return {
+    x: label.x ?? 0,
+    y: label.y ?? 0,
+    width: label.width ?? 0,
+    height: label.height ?? 0,
+    text: label.text ?? '',
+  };
+}
+
+function convertPort(port: ElkPort, parent: ElkNode): LayoutPort {
+  const parentX = parent.x ?? 0;
+  const parentY = parent.y ?? 0;
+  const side = (port.properties?.['port.side'] as string | undefined) ?? undefined;
+  return {
+    x: (port.x ?? 0) - parentX,
+    y: (port.y ?? 0) - parentY,
+    width: port.width ?? 0,
+    height: port.height ?? 0,
+    side,
+  };
+}
+
+function convertEdge(edge: ElkExtendedEdge): LayoutEdge {
+  const sections = (edge.sections ?? []).map((section) => ({
+    startPoint: convertPoint(section.startPoint),
+    endPoint: convertPoint(section.endPoint),
+    bendPoints: (section.bendPoints ?? []).map(convertPoint),
+  }));
+
+  const labels = (edge.labels ?? []).map(convertLabel);
+
+  return { sections, labels };
+}
+
+function convertPoint(point: ElkPoint | undefined): LayoutPoint {
+  if (!point) {
+    return { x: 0, y: 0 };
+  }
+  return { x: point.x ?? 0, y: point.y ?? 0 };
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,0 +1,26 @@
+export { buildBlockConnectorGraph } from './block-graph';
+export type { BuildBlockConnectorGraphOptions } from './block-graph';
+
+export { layoutBlockConnectorGraph } from './elk-layout';
+
+export type {
+  BlockConnectorGraph,
+  GraphEdge,
+  GraphEndpoint,
+  GraphLayout,
+  GraphNode,
+  GraphPort,
+  GraphPortKind,
+  LayoutConfig,
+  LayoutEdge,
+  LayoutLabel,
+  LayoutNode,
+  LayoutPoint,
+  LayoutPort,
+  LayoutSize,
+  LayoutSpacing,
+  SysMLElement,
+  TextLocation,
+  TextPosition,
+  TextRange,
+} from './types';

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,119 @@
+import type { ElementRecord } from '../generated/types';
+
+export type SysMLElement = Record<string, unknown>;
+
+export interface TextPosition {
+  line: number;
+  column: number;
+  offset?: number;
+}
+
+export interface TextRange {
+  start: TextPosition;
+  end: TextPosition;
+}
+
+export interface TextLocation {
+  uri: string;
+  range?: TextRange;
+}
+
+export type GraphPortKind = 'part' | 'port';
+
+export interface GraphPort {
+  id: string;
+  featureId: string;
+  label: string;
+  kind: GraphPortKind;
+  typeRef?: string;
+  targetNodeId?: string;
+  parentFeatureId?: string;
+  textLocation?: TextLocation;
+  raw: SysMLElement;
+}
+
+export interface GraphNode {
+  id: string;
+  elementId: string;
+  label: string;
+  kind: 'block';
+  documentation?: string;
+  textLocation?: TextLocation;
+  ports: GraphPort[];
+  raw: SysMLElement;
+  record: ElementRecord;
+}
+
+export interface GraphEndpoint {
+  nodeId: string;
+  portId: string;
+  featureId: string;
+}
+
+export interface GraphEdge {
+  id: string;
+  connectorId: string;
+  label?: string;
+  source: GraphEndpoint;
+  target: GraphEndpoint;
+  textLocation?: TextLocation;
+  raw: SysMLElement;
+}
+
+export interface BlockConnectorGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface LayoutSize {
+  width: number;
+  height: number;
+}
+
+export interface LayoutPoint {
+  x: number;
+  y: number;
+}
+
+export interface LayoutLabel extends LayoutSize, LayoutPoint {
+  text: string;
+}
+
+export interface LayoutPort extends LayoutSize, LayoutPoint {
+  side?: string;
+}
+
+export interface LayoutNode extends LayoutSize, LayoutPoint {
+  labels: LayoutLabel[];
+  ports: Record<string, LayoutPort>;
+}
+
+export interface LayoutSection {
+  startPoint: LayoutPoint;
+  endPoint: LayoutPoint;
+  bendPoints: LayoutPoint[];
+}
+
+export interface LayoutEdge {
+  sections: LayoutSection[];
+  labels: LayoutLabel[];
+}
+
+export interface GraphLayout {
+  nodes: Record<string, LayoutNode>;
+  edges: Record<string, LayoutEdge>;
+}
+
+export interface LayoutSpacing {
+  nodeNode?: number;
+  edgeEdge?: number;
+  nodeNodeBetweenLayers?: number;
+}
+
+export interface LayoutConfig {
+  direction?: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT';
+  nodeSize?: LayoutSize;
+  portSize?: LayoutSize;
+  spacing?: LayoutSpacing;
+  layoutOptions?: Record<string, string>;
+}

--- a/src/sysml-sdk.ts
+++ b/src/sysml-sdk.ts
@@ -192,3 +192,5 @@ export class SysMLSDK {
     }
   }
 }
+
+export * from './graph';

--- a/tests/graph/block-graph.test.ts
+++ b/tests/graph/block-graph.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import { buildBlockConnectorGraph, layoutBlockConnectorGraph } from '../../src/graph';
+import type { ElementRecord } from '../../src/generated/types';
+
+const PROJECT_ID = 'project-1';
+const COMMIT_ID = 'commit-1';
+
+function textLocation(uri: string, startLine: number, startColumn: number, endLine: number, endColumn: number) {
+  return {
+    uri,
+    range: {
+      start: { line: startLine, column: startColumn },
+      end: { line: endLine, column: endColumn },
+    },
+  } as const;
+}
+
+const wheelBlock: ElementRecord = {
+  id: 'element-wheel',
+  projectId: PROJECT_ID,
+  commitId: COMMIT_ID,
+  classifierId: 'sysml:BlockDefinition',
+  name: 'Wheel',
+  documentation: 'Wheel block definition',
+  payload: {
+    '@id': 'block.wheel',
+    '@type': 'BlockDefinition',
+    declaredName: 'Wheel',
+    textLocation: textLocation('Wheel.sysml', 1, 1, 6, 1),
+    ownedRelationship: [
+      {
+        '@id': 'block.wheel.rel.port.axle',
+        '@type': 'FeatureMembership',
+        ownedMember: {
+          '@id': 'block.wheel.port.axle',
+          '@type': 'PortUsage',
+          declaredName: 'axle',
+          direction: 'out',
+          textLocation: textLocation('Wheel.sysml', 2, 3, 2, 20),
+        },
+      },
+    ],
+  },
+};
+
+const vehicleBlock: ElementRecord = {
+  id: 'element-vehicle',
+  projectId: PROJECT_ID,
+  commitId: COMMIT_ID,
+  classifierId: 'sysml:BlockDefinition',
+  name: 'Vehicle',
+  documentation: 'Vehicle block definition',
+  payload: {
+    '@id': 'block.vehicle',
+    '@type': 'BlockDefinition',
+    declaredName: 'Vehicle',
+    textLocation: textLocation('Vehicle.sysml', 1, 1, 12, 1),
+    ownedRelationship: [
+      {
+        '@id': 'block.vehicle.rel.part.frontWheel',
+        '@type': 'FeatureMembership',
+        ownedMember: {
+          '@id': 'block.vehicle.part.frontWheel',
+          '@type': 'PartUsage',
+          declaredName: 'frontWheel',
+          textLocation: textLocation('Vehicle.sysml', 3, 3, 3, 30),
+          type: {
+            '@id': 'block.wheel',
+          },
+          ownedRelationship: [
+            {
+              '@id': 'block.vehicle.part.frontWheel.rel.port.axle',
+              '@type': 'FeatureMembership',
+              ownedMember: {
+                '@id': 'block.vehicle.part.frontWheel.port.axle',
+                '@type': 'PortUsage',
+                declaredName: 'axle',
+                direction: 'out',
+                textLocation: textLocation('Vehicle.sysml', 4, 5, 4, 35),
+                referencedFeature: {
+                  '@id': 'block.wheel.port.axle',
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        '@id': 'block.vehicle.rel.port.axleInterface',
+        '@type': 'FeatureMembership',
+        ownedMember: {
+          '@id': 'block.vehicle.port.axleInterface',
+          '@type': 'PortUsage',
+          declaredName: 'axleInterface',
+          direction: 'in',
+          textLocation: textLocation('Vehicle.sysml', 5, 3, 5, 36),
+        },
+      },
+      {
+        '@id': 'block.vehicle.rel.connector.axleLink',
+        '@type': 'ConnectorMembership',
+        ownedMember: {
+          '@id': 'block.vehicle.connector.axleLink',
+          '@type': 'ConnectorUsage',
+          declaredName: 'axleLink',
+          textLocation: textLocation('Vehicle.sysml', 7, 3, 9, 18),
+          ownedRelationship: [
+            {
+              '@id': 'block.vehicle.connector.axleLink.rel.end.interface',
+              '@type': 'ConnectorEndMembership',
+              ownedMember: {
+                '@id': 'block.vehicle.connector.axleLink.end.interface',
+                '@type': 'ConnectorEnd',
+                connectedFeature: {
+                  '@id': 'block.vehicle.port.axleInterface',
+                },
+              },
+            },
+            {
+              '@id': 'block.vehicle.connector.axleLink.rel.end.frontWheel',
+              '@type': 'ConnectorEndMembership',
+              ownedMember: {
+                '@id': 'block.vehicle.connector.axleLink.end.frontWheel',
+                '@type': 'ConnectorEnd',
+                connectedFeature: {
+                  '@id': 'block.vehicle.part.frontWheel.port.axle',
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const elements: ElementRecord[] = [vehicleBlock, wheelBlock];
+
+describe('buildBlockConnectorGraph', () => {
+  it('creates nodes, ports, and edges from SysML API payloads', () => {
+    const graph = buildBlockConnectorGraph(elements);
+    expect(graph.nodes).toHaveLength(2);
+    expect(graph.edges).toHaveLength(1);
+
+    const vehicleNode = graph.nodes.find((node) => node.elementId === 'block.vehicle');
+    const wheelNode = graph.nodes.find((node) => node.elementId === 'block.wheel');
+    expect(vehicleNode).toBeDefined();
+    expect(wheelNode).toBeDefined();
+    if (!vehicleNode || !wheelNode) {
+      throw new Error('Expected nodes to be defined');
+    }
+
+    expect(vehicleNode.textLocation).toEqual(textLocation('Vehicle.sysml', 1, 1, 12, 1));
+    expect(wheelNode.textLocation).toEqual(textLocation('Wheel.sysml', 1, 1, 6, 1));
+
+    const partPort = vehicleNode.ports.find((port) => port.featureId === 'block.vehicle.part.frontWheel');
+    expect(partPort).toBeDefined();
+    expect(partPort?.kind).toBe('part');
+    expect(partPort?.typeRef).toBe('block.wheel');
+    expect(partPort?.targetNodeId).toBe('block.wheel');
+
+    const nestedPort = vehicleNode.ports.find(
+      (port) => port.featureId === 'block.vehicle.part.frontWheel.port.axle',
+    );
+    expect(nestedPort).toBeDefined();
+    expect(nestedPort?.kind).toBe('port');
+    expect(nestedPort?.parentFeatureId).toBe('block.vehicle.part.frontWheel');
+
+    const blockPort = vehicleNode.ports.find(
+      (port) => port.featureId === 'block.vehicle.port.axleInterface',
+    );
+    expect(blockPort).toBeDefined();
+    expect(blockPort?.kind).toBe('port');
+
+    const wheelPort = wheelNode.ports.find((port) => port.featureId === 'block.wheel.port.axle');
+    expect(wheelPort).toBeDefined();
+    expect(wheelPort?.kind).toBe('port');
+
+    const [edge] = graph.edges;
+    expect(edge.source.nodeId).toBe(vehicleNode.id);
+    expect(edge.target.nodeId).toBe(vehicleNode.id);
+    expect(edge.source.portId).toBe('block.vehicle.port.axleInterface');
+    expect(edge.target.portId).toBe('block.vehicle.part.frontWheel.port.axle');
+    expect(edge.textLocation).toEqual(textLocation('Vehicle.sysml', 7, 3, 9, 18));
+  });
+});
+
+describe('layoutBlockConnectorGraph', () => {
+  it('produces ELK.js layout information for the thin graph', async () => {
+    const graph = buildBlockConnectorGraph(elements);
+    const layout = await layoutBlockConnectorGraph(graph, {
+      direction: 'RIGHT',
+    });
+
+    const vehicleLayout = layout.nodes['block.vehicle'];
+    const wheelLayout = layout.nodes['block.wheel'];
+    expect(vehicleLayout).toBeDefined();
+    expect(wheelLayout).toBeDefined();
+    if (!vehicleLayout || !wheelLayout) {
+      throw new Error('Expected layout nodes');
+    }
+
+    expect(Number.isFinite(vehicleLayout.x)).toBe(true);
+    expect(Number.isFinite(vehicleLayout.y)).toBe(true);
+    expect(vehicleLayout.width).toBeGreaterThan(0);
+    expect(vehicleLayout.height).toBeGreaterThan(0);
+
+    const vehiclePorts = vehicleLayout.ports;
+    expect(vehiclePorts['block.vehicle.part.frontWheel']).toBeDefined();
+    expect(vehiclePorts['block.vehicle.port.axleInterface']).toBeDefined();
+
+    const edgeLayout = layout.edges[graph.edges[0].id];
+    expect(edgeLayout).toBeDefined();
+    expect(edgeLayout.sections.length).toBeGreaterThan(0);
+    for (const section of edgeLayout.sections) {
+      expect(Number.isFinite(section.startPoint.x)).toBe(true);
+      expect(Number.isFinite(section.startPoint.y)).toBe(true);
+      expect(Number.isFinite(section.endPoint.x)).toBe(true);
+      expect(Number.isFinite(section.endPoint.y)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add thin graph data model for blocks, parts, ports, and connectors built from SysML API payloads
- provide ELK.js powered layout generation and re-export the graph utilities from the SDK entry point
- cover the new graph builder and layout with representative fixture tests and add the elkjs dependency

## Testing
- npm test *(fails: vitest binary missing because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e678989200832f87fe2340ff239caf