### PR TITLE
Add API-backed outline tree to web editor

### DIFF
--- a/doc/web-editor/editor.js
+++ b/doc/web-editor/editor.js
@@ -1,6 +1,14 @@
 (function () {
   const editorElement = document.getElementById("editor");
   const outlineElement = document.getElementById("outline");
+  const outlineForm = document.getElementById("outline-config");
+  const outlineStatusElement = document.getElementById("outline-status");
+  const apiUrlInput = document.getElementById("api-url");
+  const projectIdInput = document.getElementById("project-id");
+  const commitIdInput = document.getElementById("commit-id");
+  const elementIdInput = document.getElementById("element-id");
+  const tokenInput = document.getElementById("api-token");
+  const outlineResetButton = document.getElementById("outline-reset");
   const validationElement = document.getElementById("validation-status");
   const fileInput = document.getElementById("file-input");
   const themeToggle = document.getElementById("toggle-theme");
@@ -26,6 +34,19 @@
     "association",
     "relationship",
   ];
+
+  const OUTLINE_STORAGE_KEY = "sysml-web-editor-outline-config";
+
+  let ignoreNextChange = false;
+  let outlineMode = "heuristic";
+  let outlineTree = [];
+  const outlineNodeIndex = new Map();
+  let activeOutlineNode = null;
+  let outlineRangeMarker = null;
+  let suppressCursorSync = false;
+  let outlineOutOfSync = false;
+  let currentApiConfig = null;
+  let outlineNodeIdCounter = 0;
 
   const cm = CodeMirror.fromTextArea(editorElement, {
     mode: {
@@ -69,21 +90,26 @@
 }
 `;
 
+  ignoreNextChange = true;
   cm.setValue(defaultTemplate);
-  updateOutline(defaultTemplate);
+  updateHeuristicOutline(defaultTemplate);
   showValidation();
 
   document.getElementById("btn-new").addEventListener("click", () => {
     if (cm.getValue().trim().length === 0 || confirm("Discard current model?")) {
+      ignoreNextChange = true;
       cm.setValue("");
       cm.focus();
+      updateHeuristicOutline("");
     }
   });
 
   document.getElementById("btn-insert").addEventListener("click", () => {
     const current = cm.getValue();
     if (current.trim().length === 0) {
+      ignoreNextChange = true;
       cm.setValue(defaultTemplate);
+      updateHeuristicOutline(defaultTemplate);
     } else {
       cm.replaceRange(`\n${defaultTemplate}`, cm.getCursor());
     }
@@ -100,18 +126,78 @@
 
   cm.on("change", () => {
     const content = cm.getValue();
-    updateOutline(content);
+    if (ignoreNextChange) {
+      ignoreNextChange = false;
+    } else if (outlineMode === "heuristic") {
+      updateHeuristicOutline(content);
+    } else {
+      markOutlineOutOfSync();
+    }
     debouncedValidation();
   });
+
+  cm.on("cursorActivity", () => {
+    if (suppressCursorSync) {
+      suppressCursorSync = false;
+      return;
+    }
+
+    if (outlineMode !== "api" || outlineTree.length === 0) {
+      return;
+    }
+
+    const cursor = cm.getCursor();
+    const node = findNodeForCursor(cursor, outlineTree);
+    if (node && node !== activeOutlineNode) {
+      setActiveOutlineNode(node, { origin: "editor" });
+    } else if (!node) {
+      clearOutlineSelection();
+    }
+  });
+
+  outlineForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const config = readApiConfigFromInputs();
+    if (!config) {
+      setOutlineStatus(
+        "API URL, project, commit, and root element identifiers are required to load the outline.",
+        "warning",
+      );
+      return;
+    }
+
+    setOutlineStatus("Loading outline from API…", "note");
+    try {
+      await loadOutlineFromApi(config);
+      currentApiConfig = config;
+      outlineOutOfSync = false;
+      persistApiConfig(config);
+    } catch (error) {
+      console.error("Failed to load outline", error);
+      const message = error instanceof Error ? error.message : String(error);
+      setOutlineStatus(`Failed to load outline: ${message}`, "error");
+    }
+  });
+
+  outlineResetButton?.addEventListener("click", () => {
+    currentApiConfig = null;
+    outlineOutOfSync = false;
+    clearOutlineSelection();
+    setOutlineStatus("Outline is generated heuristically from the current editor content.", "info");
+    updateHeuristicOutline(cm.getValue());
+  });
+
+  initializeOutlineConfig();
 
   fileInput.addEventListener("change", async (event) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
     const text = await file.text();
+    ignoreNextChange = true;
     cm.setValue(text);
     cm.focus();
-    updateOutline(text);
+    updateHeuristicOutline(text);
     showValidation();
     fileInput.value = "";
   });
@@ -152,42 +238,31 @@
     }
   }
 
-  function updateOutline(content) {
-    const outline = buildOutline(content);
-    outlineElement.innerHTML = "";
-    if (outline.length === 0) {
-      const empty = document.createElement("li");
-      empty.textContent = "No structural elements detected.";
-      empty.className = "empty";
-      outlineElement.appendChild(empty);
-      return;
-    }
+  function updateHeuristicOutline(content) {
+    outlineMode = "heuristic";
+    outlineOutOfSync = false;
+    currentApiConfig = null;
+    clearRangeMarker();
 
-    for (const item of outline) {
-      const li = document.createElement("li");
-      const name = document.createElement("span");
-      name.textContent = item.name;
-      const kind = document.createElement("span");
-      kind.textContent = item.kind;
-      kind.className = "kind";
-      li.appendChild(name);
-      li.appendChild(kind);
-      li.addEventListener("click", () => {
-        cm.setCursor({ line: item.line, ch: 0 });
-        cm.focus();
-      });
-      outlineElement.appendChild(li);
+    outlineTree = buildHeuristicNodes(content);
+    activeOutlineNode = null;
+    renderOutlineTree();
+
+    if (!content || content.trim().length === 0) {
+      setOutlineStatus("Outline is generated heuristically from the current editor content.", "info");
+    } else {
+      setOutlineStatus("Outline is generated heuristically from the current editor content.", "info");
     }
   }
 
-  function buildOutline(content) {
-    const outline = [];
+  function buildHeuristicNodes(content) {
     const regex = /^(\s*)(package|part|interface|action|state|transition|constraint|requirement|view|viewpoint|usecase)\s+([A-Za-z0-9_:]+)/i;
     const lines = content.split(/\r?\n/);
+    const items = [];
     lines.forEach((line, index) => {
       const match = line.match(regex);
       if (match) {
-        outline.push({
+        items.push({
           line: index,
           indent: match[1].length,
           kind: match[2],
@@ -195,7 +270,824 @@
         });
       }
     });
-    return outline;
+
+    outlineNodeIdCounter = 0;
+    const roots = [];
+    const stack = [{ indent: -1, node: null }];
+
+    items.forEach((item, index) => {
+      const node = {
+        id: `heuristic-${outlineNodeIdCounter++}`,
+        elementId: null,
+        label: item.name,
+        name: item.name,
+        kind: item.kind,
+        range: {
+          start: { line: item.line, ch: 0 },
+          end: { line: item.line, ch: Number.MAX_SAFE_INTEGER },
+        },
+        children: [],
+        parent: null,
+        expanded: true,
+        source: "heuristic",
+      };
+
+      while (stack.length > 1 && item.indent <= stack[stack.length - 1].indent) {
+        stack.pop();
+      }
+
+      const parentEntry = stack[stack.length - 1];
+      if (parentEntry.node) {
+        node.parent = parentEntry.node;
+        parentEntry.node.children.push(node);
+      } else {
+        roots.push(node);
+      }
+
+      stack.push({ indent: item.indent, node });
+    });
+
+    return roots;
+  }
+
+  async function loadOutlineFromApi(config) {
+    const normalized = normalizeApiConfig(config);
+    const visited = new Set();
+    outlineNodeIdCounter = 0;
+
+    const element = await fetchElement(normalized, normalized.elementId);
+    if (!element) {
+      throw new Error("API returned an empty element response.");
+    }
+
+    const rootNode = await buildApiOutline(normalized, element, null, visited);
+    outlineMode = "api";
+    outlineOutOfSync = false;
+    outlineTree = rootNode ? [rootNode] : [];
+    activeOutlineNode = null;
+    clearRangeMarker();
+    renderOutlineTree();
+
+    const total = countNodes(outlineTree);
+    if (total === 0) {
+      setOutlineStatus("No owned elements were returned for the requested element.", "warning");
+    } else {
+      setOutlineStatus(`Loaded outline with ${total} element${total === 1 ? "" : "s"}.`, "success");
+    }
+
+    const rootText = rootNode?.text;
+    if (typeof rootText === "string" && rootText.trim().length > 0 && rootText !== cm.getValue()) {
+      ignoreNextChange = true;
+      cm.setValue(rootText);
+      cm.refresh();
+      showValidation();
+    }
+
+    if (rootNode?.range) {
+      setActiveOutlineNode(rootNode, { origin: "api" });
+    } else {
+      clearOutlineSelection();
+    }
+  }
+
+  async function buildApiOutline(config, element, parent, visited) {
+    const node = createOutlineNodeFromApi(element, parent);
+    if (!node.elementId) {
+      node.elementId = extractElementId(element) ?? node.id;
+    }
+
+    const elementId = node.elementId;
+    if (elementId && visited.has(elementId)) {
+      return node;
+    }
+    if (elementId) {
+      visited.add(elementId);
+    }
+
+    let ownedElements = [];
+    try {
+      ownedElements = elementId ? await fetchOwnedElements(config, elementId) : [];
+    } catch (error) {
+      console.warn("Failed to fetch owned elements", error);
+    }
+
+    for (const childEntry of ownedElements) {
+      const childId = extractElementId(childEntry);
+      if (!childId || visited.has(childId)) {
+        continue;
+      }
+
+      let childElement = childEntry;
+      if (childEntry && typeof childEntry === "object" && "element" in childEntry) {
+        childElement = childEntry.element;
+      }
+
+      if (!childElement || typeof childElement !== "object" || !extractElementId(childElement)) {
+        try {
+          childElement = await fetchElement(config, childId);
+        } catch (error) {
+          console.warn(`Failed to fetch element ${childId}`, error);
+          continue;
+        }
+      }
+
+      const childNode = await buildApiOutline(config, childElement, node, visited);
+      childNode.parent = node;
+      node.children.push(childNode);
+    }
+
+    return node;
+  }
+
+  function createOutlineNodeFromApi(element, parent) {
+    const raw = element && typeof element === "object" && "data" in element && element.data ? element.data : element;
+    const elementId = extractElementId(raw) ?? `api-node-${outlineNodeIdCounter++}`;
+    const name = pickString(
+      raw?.name,
+      raw?.shortName,
+      raw?.displayName,
+      raw?.declaredName,
+      raw?.declaredShortName,
+      raw?.payload?.declaredName,
+      raw?.payload?.name,
+      raw?.payload?.shortName,
+    );
+
+    const classifier = pickString(
+      raw?.classifierId,
+      Array.isArray(raw?.classifierIds) ? raw.classifierIds[0] : undefined,
+      raw?.payload?.["@type"],
+      raw?.specialization,
+      raw?.specializations?.[0]?.classifierId,
+      raw?.specializations?.[0]?.payload?.["@type"],
+      raw?.type,
+      raw?.@type,
+    );
+
+    const kind = simplifyClassifier(classifier);
+    const label = name ?? (kind ? `${kind}${elementId ? ` (${truncateId(elementId)})` : ""}` : elementId ?? "Unnamed element");
+
+    const textualRepresentations = collectTextualRepresentations(raw);
+    let text;
+    const ranges = [];
+    for (const representation of textualRepresentations) {
+      if (!text) {
+        const body = pickString(representation?.body, representation?.text, representation?.value);
+        if (body) {
+          text = body;
+        }
+      }
+      const parsedRanges = extractRangesFromRepresentation(representation);
+      ranges.push(...parsedRanges);
+    }
+
+    const node = {
+      id: elementId,
+      elementId,
+      label,
+      name: name ?? undefined,
+      kind: kind ?? undefined,
+      range: ranges.length > 0 ? ranges[0] : undefined,
+      ranges,
+      text,
+      children: [],
+      parent: parent ?? null,
+      expanded: parent ? false : true,
+      source: "api",
+      raw,
+    };
+
+    return node;
+  }
+
+  function collectTextualRepresentations(element) {
+    const representations = [];
+
+    function pushRepresentation(value) {
+      if (!value) return;
+      if (Array.isArray(value)) {
+        value.forEach(pushRepresentation);
+      } else if (typeof value === "object") {
+        representations.push(value);
+      }
+    }
+
+    if (element?.textualRepresentation) pushRepresentation(element.textualRepresentation);
+    if (element?.textualRepresentations) pushRepresentation(element.textualRepresentations);
+    if (element?.representations) pushRepresentation(element.representations);
+    if (element?.payload?.textualRepresentation) pushRepresentation(element.payload.textualRepresentation);
+    if (element?.payload?.textualRepresentations) pushRepresentation(element.payload.textualRepresentations);
+    if (element?.specializations) {
+      for (const specialization of element.specializations) {
+        if (specialization?.textualRepresentation) pushRepresentation(specialization.textualRepresentation);
+        if (specialization?.textualRepresentations) pushRepresentation(specialization.textualRepresentations);
+        if (specialization?.payload?.textualRepresentation) pushRepresentation(specialization.payload.textualRepresentation);
+        if (specialization?.payload?.textualRepresentations) pushRepresentation(specialization.payload.textualRepresentations);
+      }
+    }
+
+    return representations;
+  }
+
+  function extractRangesFromRepresentation(representation) {
+    const sources = [];
+    if (!representation || typeof representation !== "object") {
+      return sources;
+    }
+
+    const rawRanges = representation.ranges ?? representation.range ?? representation.sourceRanges ?? representation.locations;
+    if (Array.isArray(rawRanges)) {
+      for (const range of rawRanges) {
+        const normalized = normalizeRange(range);
+        if (normalized) {
+          sources.push(normalized);
+        }
+      }
+    } else if (rawRanges) {
+      const normalized = normalizeRange(rawRanges);
+      if (normalized) {
+        sources.push(normalized);
+      }
+    }
+
+    return sources;
+  }
+
+  function normalizeRange(range) {
+    if (!range || typeof range !== "object") {
+      return undefined;
+    }
+
+    const start = normalizePosition(range.start ?? range.startPosition ?? range.begin ?? {
+      line: range.startLine ?? range.beginLine ?? range.lineStart,
+      column: range.startColumn ?? range.beginColumn ?? range.columnStart,
+    });
+    const end = normalizePosition(range.end ?? range.endPosition ?? range.finish ?? {
+      line: range.endLine ?? range.finishLine ?? range.lineEnd,
+      column: range.endColumn ?? range.finishColumn ?? range.columnEnd,
+    });
+
+    if (!start || !end) {
+      return undefined;
+    }
+
+    if (comparePositions(start, end) >= 0) {
+      return undefined;
+    }
+
+    return { start, end };
+  }
+
+  function normalizePosition(position) {
+    if (!position) {
+      return undefined;
+    }
+
+    if (typeof position === "number") {
+      return { line: Math.max(0, position), ch: 0 };
+    }
+
+    if (typeof position !== "object") {
+      return undefined;
+    }
+
+    const lineCandidate = pickNumber(
+      position.line,
+      position.lineNumber,
+      position.row,
+      position.startLine,
+      position.beginLine,
+      position.lineIndex,
+    );
+    const columnCandidate = pickNumber(
+      position.column,
+      position.columnNumber,
+      position.col,
+      position.character,
+      position.startColumn,
+      position.beginColumn,
+    );
+
+    if (lineCandidate === undefined || columnCandidate === undefined) {
+      return undefined;
+    }
+
+    const line = lineCandidate > 0 ? lineCandidate - 1 : lineCandidate;
+    const ch = columnCandidate > 0 ? columnCandidate - 1 : columnCandidate;
+
+    return { line: Math.max(0, line), ch: Math.max(0, ch) };
+  }
+
+  function pickNumber(...values) {
+    for (const value of values) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  function pickString(...values) {
+    for (const value of values) {
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+    return undefined;
+  }
+
+  function simplifyClassifier(value) {
+    if (!value || typeof value !== "string") {
+      return undefined;
+    }
+    const parts = value.split(/[:#\/]/);
+    return parts[parts.length - 1] || value;
+  }
+
+  function truncateId(id) {
+    return typeof id === "string" && id.length > 12 ? `${id.slice(0, 12)}…` : id;
+  }
+
+  function countNodes(nodes) {
+    if (!Array.isArray(nodes)) {
+      return 0;
+    }
+    return nodes.reduce((total, node) => total + 1 + countNodes(node.children ?? []), 0);
+  }
+
+  function setOutlineStatus(message, variant = "info") {
+    if (!outlineStatusElement) {
+      return;
+    }
+    outlineStatusElement.textContent = message;
+    outlineStatusElement.className = `status ${variant}`;
+  }
+
+  function renderOutlineTree() {
+    if (!outlineElement) {
+      return;
+    }
+
+    outlineNodeIndex.clear();
+    outlineElement.innerHTML = "";
+
+    if (!outlineTree || outlineTree.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "empty";
+      empty.textContent =
+        outlineMode === "api"
+          ? "No owned elements were returned for the requested element."
+          : "No structural elements detected.";
+      outlineElement.appendChild(empty);
+      return;
+    }
+
+    for (const node of outlineTree) {
+      outlineElement.appendChild(renderOutlineNode(node));
+    }
+  }
+
+  function renderOutlineNode(node) {
+    outlineNodeIndex.set(node.id, node);
+
+    const li = document.createElement("li");
+    li.className = "outline-node";
+
+    const row = document.createElement("div");
+    row.className = "outline-row";
+    if (activeOutlineNode === node) {
+      row.classList.add("selected");
+    }
+    if (node.elementId) {
+      row.title = node.elementId;
+    }
+
+    const toggle = document.createElement(node.children.length > 0 ? "button" : "span");
+    toggle.className = node.children.length > 0 ? "outline-toggle" : "outline-spacer";
+    if (node.children.length > 0) {
+      toggle.type = "button";
+      toggle.setAttribute("aria-label", node.expanded ? "Collapse" : "Expand");
+      toggle.textContent = node.expanded ? "▾" : "▸";
+      toggle.addEventListener("click", (event) => {
+        event.stopPropagation();
+        node.expanded = !node.expanded;
+        renderOutlineTree();
+      });
+    }
+    row.appendChild(toggle);
+
+    const labelButton = document.createElement("button");
+    labelButton.type = "button";
+    labelButton.className = "outline-label";
+    labelButton.textContent = node.label ?? node.name ?? node.elementId ?? "Unnamed element";
+    labelButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      setActiveOutlineNode(node, { origin: "outline" });
+    });
+    row.appendChild(labelButton);
+
+    if (node.kind) {
+      const kind = document.createElement("span");
+      kind.className = "outline-kind";
+      kind.textContent = node.kind;
+      row.appendChild(kind);
+    }
+
+    row.addEventListener("click", () => {
+      setActiveOutlineNode(node, { origin: "outline" });
+    });
+
+    li.appendChild(row);
+
+    if (node.children.length > 0) {
+      if (!node.expanded) {
+        for (const child of node.children) {
+          child.parent = node;
+        }
+      } else {
+        const childrenList = document.createElement("ul");
+        childrenList.className = "outline-children";
+        for (const child of node.children) {
+          child.parent = node;
+          childrenList.appendChild(renderOutlineNode(child));
+        }
+        li.appendChild(childrenList);
+      }
+    }
+
+    return li;
+  }
+
+  function setActiveOutlineNode(node, options = {}) {
+    if (!node) {
+      clearOutlineSelection();
+      return;
+    }
+
+    ensureNodeVisible(node);
+
+    if (activeOutlineNode !== node) {
+      activeOutlineNode = node;
+      renderOutlineTree();
+    }
+
+    if (node.range) {
+      const scroll = options.origin !== "editor";
+      const updateCursor = options.origin === "outline" || options.origin === "api";
+      highlightEditorRange(node.range, { scroll, updateCursor });
+    } else {
+      clearRangeMarker();
+    }
+  }
+
+  function highlightEditorRange(range, { scroll = true, updateCursor = false } = {}) {
+    if (!range) {
+      clearRangeMarker();
+      return;
+    }
+
+    const clamped = clampRangeToDocument(range);
+    clearRangeMarker();
+    outlineRangeMarker = cm.markText(clamped.start, clamped.end, {
+      className: "cm-outline-range",
+      clearOnEnter: false,
+    });
+
+    if (updateCursor) {
+      suppressCursorSync = true;
+      cm.setCursor(clamped.start);
+    }
+
+    if (scroll) {
+      cm.scrollIntoView({ from: clamped.start, to: clamped.end }, 80);
+    }
+  }
+
+  function clearRangeMarker() {
+    if (outlineRangeMarker) {
+      outlineRangeMarker.clear();
+      outlineRangeMarker = null;
+    }
+  }
+
+  function clearOutlineSelection() {
+    if (activeOutlineNode) {
+      activeOutlineNode = null;
+      renderOutlineTree();
+    }
+    clearRangeMarker();
+  }
+
+  function ensureNodeVisible(node) {
+    let current = node?.parent;
+    while (current) {
+      if (!current.expanded) {
+        current.expanded = true;
+      }
+      current = current.parent;
+    }
+  }
+
+  function clampRangeToDocument(range) {
+    const lastLine = Math.max(0, cm.lineCount() - 1);
+
+    const clampLine = (line) => Math.min(Math.max(line, 0), lastLine);
+    const clampCh = (line, ch) => {
+      const text = cm.getLine(line) ?? "";
+      return Math.min(Math.max(ch, 0), text.length);
+    };
+
+    let startLine = clampLine(range.start.line);
+    let startCh = clampCh(startLine, range.start.ch);
+    let endLine = clampLine(range.end.line);
+    let endCh = clampCh(endLine, range.end.ch);
+
+    if (comparePositions({ line: startLine, ch: startCh }, { line: endLine, ch: endCh }) >= 0) {
+      endLine = startLine;
+      endCh = clampCh(endLine, startCh + 1);
+    }
+
+    return {
+      start: { line: startLine, ch: startCh },
+      end: { line: endLine, ch: endCh },
+    };
+  }
+
+  function findNodeForCursor(position, nodes) {
+    for (const node of nodes) {
+      if (node.range && isPositionInRange(position, node.range)) {
+        const descendant = findNodeForCursor(position, node.children ?? []);
+        return descendant ?? node;
+      }
+
+      const childMatch = findNodeForCursor(position, node.children ?? []);
+      if (childMatch) {
+        return childMatch;
+      }
+    }
+    return null;
+  }
+
+  function comparePositions(a, b) {
+    if (a.line < b.line) return -1;
+    if (a.line > b.line) return 1;
+    if (a.ch < b.ch) return -1;
+    if (a.ch > b.ch) return 1;
+    return 0;
+  }
+
+  function isPositionInRange(position, range) {
+    return comparePositions(position, range.start) >= 0 && comparePositions(position, range.end) <= 0;
+  }
+
+  function markOutlineOutOfSync() {
+    if (outlineMode !== "api" || outlineOutOfSync) {
+      return;
+    }
+    outlineOutOfSync = true;
+    setOutlineStatus(
+      "Editor content has changed; API-derived ranges may no longer align until the outline is reloaded.",
+      "warning",
+    );
+  }
+
+  function normalizeApiConfig(config) {
+    return {
+      baseUrl: trimTrailingSlash(config.baseUrl),
+      projectId: config.projectId,
+      commitId: config.commitId,
+      elementId: config.elementId,
+      token: config.token,
+    };
+  }
+
+  function trimTrailingSlash(url) {
+    return url.endsWith("/") ? url.replace(/\/+$/, "") : url;
+  }
+
+  function buildElementUrl(config, elementId) {
+    const base = trimTrailingSlash(config.baseUrl);
+    return `${base}/projects/${encodeURIComponent(config.projectId)}/commits/${encodeURIComponent(config.commitId)}/elements/${encodeURIComponent(elementId)}`;
+  }
+
+  async function fetchElement(config, elementId) {
+    const url = buildElementUrl(config, elementId);
+    const payload = await fetchFromApi(url, config.token);
+    if (!payload) {
+      return null;
+    }
+    if (payload.data) {
+      return payload.data;
+    }
+    if (payload.element) {
+      return payload.element;
+    }
+    return payload;
+  }
+
+  async function fetchOwnedElements(config, elementId) {
+    const url = `${buildElementUrl(config, elementId)}/ownedElements`;
+    const payload = await fetchFromApi(url, config.token);
+    if (!payload) {
+      return [];
+    }
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+    if (Array.isArray(payload.items)) {
+      return payload.items;
+    }
+    if (Array.isArray(payload.elements)) {
+      return payload.elements;
+    }
+    if (Array.isArray(payload.data)) {
+      return payload.data;
+    }
+    if (Array.isArray(payload.ownedElements)) {
+      return payload.ownedElements;
+    }
+    return [];
+  }
+
+  async function fetchFromApi(url, token) {
+    const headers = { Accept: "application/json" };
+    if (token) {
+      headers.Authorization = formatAuthorizationToken(token);
+    }
+
+    let response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (error) {
+      throw new Error(
+        error instanceof Error ? `Network error while contacting the SysML API: ${error.message}` : "Network error while contacting the SysML API.",
+      );
+    }
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      let message = `${response.status} ${response.statusText}`;
+      if (text) {
+        try {
+          const parsed = JSON.parse(text);
+          message = pickString(parsed.message, parsed.error, parsed.title, message) ?? message;
+        } catch (error) {
+          // ignore JSON parse failure for error response
+        }
+      }
+      throw new Error(message);
+    }
+
+    if (!text) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      throw new Error("Failed to parse API response as JSON.");
+    }
+  }
+
+  function formatAuthorizationToken(token) {
+    if (!token) {
+      return token;
+    }
+    return /^Bearer\s/i.test(token) ? token : `Bearer ${token}`;
+  }
+
+  function extractElementId(value) {
+    if (!value || typeof value !== "object") {
+      return undefined;
+    }
+    if (typeof value.elementId === "string") {
+      return value.elementId;
+    }
+    if (typeof value.id === "string") {
+      return value.id;
+    }
+    if (typeof value.sysmlId === "string") {
+      return value.sysmlId;
+    }
+    if (typeof value["@id"] === "string") {
+      return value["@id"];
+    }
+    if (value.data) {
+      return extractElementId(value.data);
+    }
+    if (value.element) {
+      return extractElementId(value.element);
+    }
+    return undefined;
+  }
+
+  function readApiConfigFromInputs() {
+    const baseUrl = apiUrlInput?.value.trim();
+    const projectId = projectIdInput?.value.trim();
+    const commitId = commitIdInput?.value.trim();
+    const elementId = elementIdInput?.value.trim();
+    const token = tokenInput?.value.trim();
+
+    if (!baseUrl || !projectId || !commitId || !elementId) {
+      return null;
+    }
+
+    return {
+      baseUrl,
+      projectId,
+      commitId,
+      elementId,
+      token: token || undefined,
+    };
+  }
+
+  function applyConfigToInputs(config) {
+    if (!config) return;
+    if (config.baseUrl && apiUrlInput) apiUrlInput.value = config.baseUrl;
+    if (config.projectId && projectIdInput) projectIdInput.value = config.projectId;
+    if (config.commitId && commitIdInput) commitIdInput.value = config.commitId;
+    if (config.elementId && elementIdInput) elementIdInput.value = config.elementId;
+    if (config.token && tokenInput) tokenInput.value = config.token;
+  }
+
+  function persistApiConfig(config) {
+    if (!window.localStorage) {
+      return;
+    }
+    try {
+      const { token, ...rest } = config;
+      localStorage.setItem(OUTLINE_STORAGE_KEY, JSON.stringify(rest));
+    } catch (error) {
+      console.warn("Failed to persist outline configuration", error);
+    }
+  }
+
+  function readStoredConfig() {
+    if (!window.localStorage) {
+      return null;
+    }
+    try {
+      const raw = localStorage.getItem(OUTLINE_STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn("Failed to read stored outline configuration", error);
+      return null;
+    }
+  }
+
+  function readApiConfigFromQuery() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const baseUrl = pickString(params.get("api"), params.get("apiUrl"));
+      const projectId = pickString(params.get("project"), params.get("projectId"));
+      const commitId = pickString(params.get("commit"), params.get("commitId"));
+      const elementId = pickString(params.get("element"), params.get("elementId"));
+      const token = pickString(params.get("token"), params.get("bearer"));
+
+      if (baseUrl && projectId && commitId && elementId) {
+        return {
+          baseUrl,
+          projectId,
+          commitId,
+          elementId,
+          token: token ?? undefined,
+        };
+      }
+      return null;
+    } catch (error) {
+      console.warn("Failed to parse outline configuration from query string", error);
+      return null;
+    }
+  }
+
+  function initializeOutlineConfig() {
+    const stored = readStoredConfig();
+    if (stored) {
+      applyConfigToInputs(stored);
+    }
+
+    const fromQuery = readApiConfigFromQuery();
+    if (fromQuery) {
+      applyConfigToInputs(fromQuery);
+      const config = readApiConfigFromInputs();
+      if (config) {
+        setOutlineStatus("Loading outline from API…", "note");
+        loadOutlineFromApi(config)
+          .then(() => {
+            currentApiConfig = config;
+            outlineOutOfSync = false;
+          })
+          .catch((error) => {
+            console.error("Failed to auto-load outline", error);
+            const message = error instanceof Error ? error.message : String(error);
+            setOutlineStatus(`Failed to load outline: ${message}`, "error");
+          });
+      }
+    }
   }
 
   function validate(content) {

--- a/doc/web-editor/index.html
+++ b/doc/web-editor/index.html
@@ -29,7 +29,38 @@
       <aside class="side-pane">
         <section class="panel">
           <h2>Model Outline</h2>
-          <ul id="outline" aria-live="polite"></ul>
+          <form id="outline-config" class="outline-config" autocomplete="off">
+            <label class="field">
+              <span class="field-label">API URL</span>
+              <input type="url" id="api-url" name="api-url" placeholder="https://api.example.com" />
+            </label>
+            <div class="outline-config-grid">
+              <label class="field">
+                <span class="field-label">Project</span>
+                <input type="text" id="project-id" name="project-id" placeholder="project-id" />
+              </label>
+              <label class="field">
+                <span class="field-label">Commit</span>
+                <input type="text" id="commit-id" name="commit-id" placeholder="commit-id" />
+              </label>
+              <label class="field">
+                <span class="field-label">Root element</span>
+                <input type="text" id="element-id" name="element-id" placeholder="element-id" />
+              </label>
+            </div>
+            <label class="field">
+              <span class="field-label">Token (optional)</span>
+              <input type="password" id="api-token" name="api-token" placeholder="Bearer token" autocomplete="off" />
+            </label>
+            <div class="outline-actions">
+              <button type="submit">Load outline</button>
+              <button type="button" id="outline-reset">Use editor outline</button>
+            </div>
+          </form>
+          <p id="outline-status" class="status info">
+            Outline is generated heuristically from the current editor content.
+          </p>
+          <ul id="outline" class="outline-tree" aria-live="polite"></ul>
         </section>
         <section class="panel">
           <h2>Validation</h2>
@@ -42,9 +73,10 @@
             work as a <code>.sysml</code> file or paste it into other SysML v2 tooling.
           </p>
           <p>
-            The outline is generated heuristically from key declarations such as
-            <code>package</code>, <code>part</code>, <code>interface</code>, and
-            <code>action</code> blocks.
+            Configure the outline panel above to load the model hierarchy from the
+            SysML v2 API. Selecting a node reveals its source range in the editor
+            and moving the caret in the editor highlights the corresponding node in
+            the outline.
           </p>
         </section>
       </aside>

--- a/doc/web-editor/styles.css
+++ b/doc/web-editor/styles.css
@@ -144,6 +144,10 @@ body {
   line-height: 1.6;
 }
 
+.status.info {
+  color: rgba(15, 23, 42, 0.7);
+}
+
 .status.success {
   color: #15803d;
 }
@@ -152,8 +156,124 @@ body {
   color: #9a3412;
 }
 
+.status.error {
+  color: #b91c1c;
+}
+
+.status.note {
+  color: #1d4ed8;
+}
+
+.status.note code {
+  background: rgba(37, 78, 216, 0.12);
+  border-radius: 0.35rem;
+  padding: 0.1rem 0.3rem;
+}
+
+.status.warning,
+.status.error,
+.status.note {
+  font-weight: 600;
+}
+
 .status .issue {
   display: block;
+}
+
+body.dark .status.info {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+body.dark .status.warning {
+  color: #fb923c;
+}
+
+body.dark .status.error {
+  color: #f87171;
+}
+
+body.dark .status.note {
+  color: #93c5fd;
+}
+
+body.dark .status.note code {
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.outline-config {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.outline-config .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.outline-config .field-label {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+body.dark .outline-config .field-label {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.outline-config input {
+  border-radius: 0.45rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.95);
+  color: inherit;
+}
+
+body.dark .outline-config input {
+  background: rgba(30, 41, 59, 0.7);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.outline-config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.75rem;
+}
+
+.outline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.outline-actions button {
+  background: var(--accent);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  color: var(--accent-contrast);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.outline-actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(56, 189, 248, 0.35);
+}
+
+.outline-actions button:active {
+  transform: translateY(0);
+  box-shadow: inset 0 2px 4px rgba(15, 23, 42, 0.35);
+}
+
+.outline-actions button#outline-reset {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  color: inherit;
 }
 
 #outline {
@@ -165,36 +285,124 @@ body {
   gap: 0.35rem;
 }
 
-#outline li {
+#outline .empty {
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+body.dark #outline .empty {
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.outline-node {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.outline-row {
+  display: flex;
   align-items: center;
+  gap: 0.5rem;
   padding: 0.35rem 0.5rem;
   border-radius: 0.5rem;
-  background: rgba(59, 130, 246, 0.07);
   border: 1px solid rgba(59, 130, 246, 0.18);
+  background: rgba(59, 130, 246, 0.07);
   cursor: pointer;
   transition: background 0.2s ease;
 }
 
-#outline li:hover {
+.outline-row:hover {
   background: rgba(59, 130, 246, 0.18);
 }
 
-#outline span.kind {
-  font-size: 0.75rem;
+.outline-row.selected {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.outline-toggle,
+.outline-spacer {
+  width: 1.35rem;
+  height: 1.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.outline-toggle {
+  cursor: pointer;
+  border-radius: 0.35rem;
+}
+
+.outline-toggle:hover {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.outline-label {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.outline-kind {
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: rgba(15, 23, 42, 0.6);
 }
 
-body.dark #outline li {
+.outline-children {
+  list-style: none;
+  margin: 0;
+  margin-left: 1.5rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+body.dark .outline-row {
   background: rgba(59, 130, 246, 0.1);
   border-color: rgba(59, 130, 246, 0.3);
 }
 
-body.dark #outline li:hover {
+body.dark .outline-row:hover {
   background: rgba(59, 130, 246, 0.25);
+}
+
+body.dark .outline-row.selected {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+body.dark .outline-kind {
+  color: rgba(226, 232, 240, 0.6);
+}
+
+body.dark .outline-children {
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.CodeMirror .cm-outline-range {
+  background: rgba(56, 189, 248, 0.25);
+  border-bottom: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+body.dark .CodeMirror .cm-outline-range {
+  background: rgba(56, 189, 248, 0.35);
+  border-bottom-color: rgba(56, 189, 248, 0.5);
 }
 
 .app-footer {


### PR DESCRIPTION
## Summary
- add an API configuration form that loads outlines via the element and ownedElements endpoints
- render a hierarchical outline tree with bidirectional synchronization between tree nodes and CodeMirror selections
- refresh styling and highlighting so API-derived source ranges are emphasized inside the editor

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67886f5c4832fbe81d6ff170d34ba