### PR TITLE
Fix outline builder @type access syntax

### DIFF
--- a/doc/web-editor/editor.js
+++ b/doc/web-editor/editor.js
@@ -421,7 +421,7 @@
       raw?.specializations?.[0]?.classifierId,
       raw?.specializations?.[0]?.payload?.["@type"],
       raw?.type,
-      raw?.@type,
+      raw?.["@type"],
     );
 
     const kind = simplifyClassifier(classifier);


### PR DESCRIPTION
## Summary
- fix the API outline builder to read @type metadata using bracket notation so optional chaining remains valid JavaScript

## Testing
- node --check doc/web-editor/editor.js

------
https://chatgpt.com/codex/tasks/task_e_68e67ea85ec0832f83b6ccad0c21f6cf