### PR TITLE
Replace fail call in project commit test

### DIFF
--- a/tests/api/project-flow.test.ts
+++ b/tests/api/project-flow.test.ts
@@ -59,7 +59,7 @@ describeIfApi('Project and commit flows', () => {
 
   testIfApi('lists commits including the new commit', async () => {
     if (!latestCommitId) {
-      fail('Commit was not created in previous step');
+      throw new Error('Commit was not created in previous step');
     }
     const commits = await sdk.listCommits({ projectId, branchId: defaultBranch, limit: 5 });
     const ids = commits.items.map((item) => item.id);


### PR DESCRIPTION
## Summary
- replace the undefined fail() reference in the project flow commit test with an Error throw

## Testing
- not run (SysML API service is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e67e85be40832fa93f97a5956d9db3