### PR TITLE
Add outline panel synced with SysML API

### DIFF
--- a/apps/vue-monaco-editor/env.d.ts
+++ b/apps/vue-monaco-editor/env.d.ts
@@ -2,6 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_VALIDATION_URL?: string;
+  readonly VITE_SYSML_API_URL?: string;
+  readonly VITE_SYSML_PROJECT_ID?: string;
+  readonly VITE_SYSML_COMMIT_ID?: string;
+  readonly VITE_SYSML_ROOT_ELEMENT_ID?: string;
 }
 
 interface ImportMeta {

--- a/apps/vue-monaco-editor/src/style.css
+++ b/apps/vue-monaco-editor/src/style.css
@@ -108,6 +108,141 @@ body {
   border-bottom: 1px solid rgba(148, 163, 184, 0.1);
 }
 
+.outline-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.outline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.outline-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.outline-refresh {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+  font-size: 0.8125rem;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+}
+
+.outline-refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.outline-config {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.outline-config label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.outline-config input {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  color: inherit;
+  font-size: 0.8125rem;
+}
+
+.outline-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 0;
+}
+
+.outline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.outline-node {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: none;
+  background: rgba(30, 41, 59, 0.55);
+  color: inherit;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.5rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.outline-node:hover:not(:disabled) {
+  background: rgba(51, 65, 85, 0.7);
+}
+
+.outline-node:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.outline-node.active {
+  background: rgba(59, 130, 246, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.6);
+}
+
+.outline-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.outline-meta {
+  font-size: 0.7rem;
+  opacity: 0.75;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.outline-status,
+.outline-hint,
+.outline-error {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.outline-hint {
+  opacity: 0.7;
+}
+
+.outline-error {
+  color: #fecaca;
+}
+
 .status-pill {
   display: inline-flex;
   align-items: center;
@@ -197,6 +332,14 @@ body {
   border-radius: 999px;
   padding: 0.2rem 0.6rem;
   font-size: 0.75rem;
+}
+
+.monaco-editor .outline-highlight {
+  background-color: rgba(59, 130, 246, 0.2);
+}
+
+.monaco-editor .margin .outline-glyph {
+  border-left: 3px solid rgba(96, 165, 250, 0.85);
 }
 
 @media (max-width: 1080px) {


### PR DESCRIPTION
## Summary
- add a configurable Outline panel that loads the model hierarchy from the element and owned-elements API endpoints
- keep outline selections and editor cursor positions in sync, including highlighted ranges in Monaco
- style the outline UI and expose environment variables so deployments can provide the API, project, commit, and root element IDs

## Testing
- npm test *(fails: vitest cannot resolve elkjs/lib/elk.bundled.js during graph test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e67c4fdc28832f82a2a94a1c089006