### PR TITLE
Add bundle export utilities

### DIFF
--- a/src/sysml-sdk.ts
+++ b/src/sysml-sdk.ts
@@ -1,13 +1,18 @@
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
 import { SysMLApiClient, SysMLRequestError, type SysMLClientConfig } from './generated/client';
+import packageJson from '../package.json' assert { type: 'json' };
 import type {
   CommitListResponse,
   CommitResponse,
+  CommitSummary,
   CreateCommitParams,
   CreateElementParams,
   CreateProjectParams,
   DeleteElementParams,
   DeleteProjectParams,
   ElementResponse,
+  ElementRecord,
   GetCommitParams,
   GetElementParams,
   GetProjectParams,
@@ -17,6 +22,7 @@ import type {
   ListProjectsParams,
   ProjectListResponse,
   ProjectResponse,
+  ProjectSummary,
   UpdateElementParams,
 } from './generated/types';
 import { ZodError } from './utils/zod-lite';
@@ -25,12 +31,14 @@ export type { SysMLClientConfig } from './generated/client';
 export type {
   CommitListResponse,
   CommitResponse,
+  CommitSummary,
   CreateCommitParams,
   CreateElementParams,
   CreateProjectParams,
   DeleteElementParams,
   DeleteProjectParams,
   ElementResponse,
+  ElementRecord,
   GetCommitParams,
   GetElementParams,
   GetProjectParams,
@@ -39,9 +47,191 @@ export type {
   ListElementsResponse,
   ListProjectsParams,
   ProjectListResponse,
+  ProjectSummary,
   ProjectResponse,
   UpdateElementParams,
 } from './generated/types';
+
+const CHECKSUM_ALGORITHM = 'sha256' as const;
+const SYSML_TEXT_FORMAT = 'sysml-text' as const;
+const API_JSON_FORMAT = 'api-json' as const;
+const ELEMENT_DIRECTORY = 'elements';
+const MANIFEST_FILE_NAME = 'manifest.json';
+const API_BUNDLE_FILE_NAME = 'api-bundle.json';
+const DEFAULT_BUNDLE_VERSION = '1.0.0';
+const DEFAULT_LIST_LIMIT = 100;
+const SDK_VERSION: string = (packageJson as { version: string }).version ?? 'unknown';
+
+export type BundleFormat = typeof SYSML_TEXT_FORMAT | typeof API_JSON_FORMAT;
+
+export interface BundleFile {
+  path: string;
+  contents: string;
+}
+
+export interface BundleManifestEntry {
+  path: string;
+  checksum: string;
+  size: number;
+}
+
+export interface BundleManifest {
+  format: BundleFormat;
+  bundleVersion: string;
+  sdkVersion: string;
+  generatedAt: string;
+  checksumAlgorithm: typeof CHECKSUM_ALGORITHM;
+  project: ProjectSummary;
+  commit: CommitSummary;
+  elementCount: number;
+  files: BundleManifestEntry[];
+}
+
+export interface ExportBundle {
+  manifest: BundleManifest;
+  files: BundleFile[];
+}
+
+export interface ExportBundleParams {
+  projectId: string;
+  commitId: string;
+}
+
+interface BundleContext {
+  project: ProjectSummary;
+  commit: CommitSummary;
+  elements: ElementRecord[];
+  generatedAt: string;
+}
+
+function computeChecksum(contents: string): string {
+  return createHash(CHECKSUM_ALGORITHM).update(contents, 'utf8').digest('hex');
+}
+
+function computeSize(contents: string): number {
+  return Buffer.byteLength(contents, 'utf8');
+}
+
+function sortElements(elements: ElementRecord[]): ElementRecord[] {
+  return [...elements].sort((a, b) => {
+    const nameA = (a.name ?? '').toLocaleLowerCase();
+    const nameB = (b.name ?? '').toLocaleLowerCase();
+    const nameCompare = nameA.localeCompare(nameB);
+    if (nameCompare !== 0) {
+      return nameCompare;
+    }
+    const classifierCompare = a.classifierId.localeCompare(b.classifierId);
+    if (classifierCompare !== 0) {
+      return classifierCompare;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function sortFilesByPath(files: BundleFile[]): BundleFile[] {
+  return [...files].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function escapeTripleQuotes(value: string): string {
+  return value.replace(/"""/g, '\\"""');
+}
+
+function serializeElementToSysMLText(element: ElementRecord): string {
+  const lines: string[] = [];
+  lines.push(`/// Element ${element.id}`);
+  const displayName = element.name ?? element.id;
+  lines.push(`element ${element.classifierId} ${JSON.stringify(displayName)} {`);
+  lines.push(`  id = ${JSON.stringify(element.id)}`);
+  lines.push(`  project = ${JSON.stringify(element.projectId)}`);
+  lines.push(`  commit = ${JSON.stringify(element.commitId)}`);
+  lines.push(`  classifier = ${JSON.stringify(element.classifierId)}`);
+  if (element.name) {
+    lines.push(`  name = ${JSON.stringify(element.name)}`);
+  }
+  if (element.documentation) {
+    lines.push('  documentation = """');
+    for (const docLine of element.documentation.split(/\r?\n/)) {
+      lines.push(`    ${escapeTripleQuotes(docLine)}`);
+    }
+    lines.push('  """');
+  }
+
+  const payloadJson = JSON.stringify(element.payload, null, 2) ?? '{}';
+  const payloadLines = payloadJson.split('\n');
+  if (payloadLines.length === 0) {
+    lines.push('  payload = {}');
+  } else if (payloadLines.length === 1) {
+    lines.push(`  payload = ${payloadLines[0]}`);
+  } else {
+    lines.push(`  payload = ${payloadLines[0]}`);
+    for (const payloadLine of payloadLines.slice(1, -1)) {
+      lines.push(`    ${payloadLine}`);
+    }
+    lines.push(`  ${payloadLines[payloadLines.length - 1]}`);
+  }
+  lines.push('}');
+  return `${lines.join('\n')}\n`;
+}
+
+function createSysMLTextFiles(elements: ElementRecord[]): BundleFile[] {
+  return elements.map((element) => ({
+    path: `${ELEMENT_DIRECTORY}/${element.id}.sysml`,
+    contents: serializeElementToSysMLText(element),
+  }));
+}
+
+function createApiBundleFile(context: BundleContext): BundleFile {
+  const payload = {
+    format: API_JSON_FORMAT,
+    bundleVersion: DEFAULT_BUNDLE_VERSION,
+    sdkVersion: SDK_VERSION,
+    generatedAt: context.generatedAt,
+    project: { ...context.project },
+    commit: { ...context.commit },
+    elementCount: context.elements.length,
+    elements: context.elements.map((element) => ({
+      id: element.id,
+      classifierId: element.classifierId,
+      name: element.name,
+      documentation: element.documentation,
+      payload: element.payload,
+    })),
+  };
+  return {
+    path: API_BUNDLE_FILE_NAME,
+    contents: `${JSON.stringify(payload, null, 2)}\n`,
+  };
+}
+
+function buildManifest(format: BundleFormat, context: BundleContext, files: BundleFile[]): BundleManifest {
+  const sortedFiles = sortFilesByPath(files);
+  return {
+    format,
+    bundleVersion: DEFAULT_BUNDLE_VERSION,
+    sdkVersion: SDK_VERSION,
+    generatedAt: context.generatedAt,
+    checksumAlgorithm: CHECKSUM_ALGORITHM,
+    project: { ...context.project },
+    commit: { ...context.commit },
+    elementCount: context.elements.length,
+    files: sortedFiles.map((file) => ({
+      path: file.path,
+      checksum: computeChecksum(file.contents),
+      size: computeSize(file.contents),
+    })),
+  };
+}
+
+function serializeManifest(manifest: BundleManifest): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function createManifestFile(manifest: BundleManifest): BundleFile {
+  return {
+    path: MANIFEST_FILE_NAME,
+    contents: serializeManifest(manifest),
+  };
+}
 
 export abstract class SysMLError extends Error {
   constructor(message: string, public readonly cause?: unknown) {
@@ -190,6 +380,82 @@ export class SysMLSDK {
     } catch (error) {
       this.transformError(error);
     }
+  }
+
+  async exportSysMLTextBundle(params: ExportBundleParams): Promise<ExportBundle> {
+    try {
+      const context = await this.buildBundleContext(params);
+      const dataFiles = sortFilesByPath(createSysMLTextFiles(context.elements));
+      const manifest = buildManifest(SYSML_TEXT_FORMAT, context, dataFiles);
+      const manifestFile = createManifestFile(manifest);
+      return {
+        manifest,
+        files: [...dataFiles, manifestFile],
+      };
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  async exportApiBundle(params: ExportBundleParams): Promise<ExportBundle> {
+    try {
+      const context = await this.buildBundleContext(params);
+      const dataFile = createApiBundleFile(context);
+      const dataFiles = sortFilesByPath([dataFile]);
+      const manifest = buildManifest(API_JSON_FORMAT, context, dataFiles);
+      const manifestFile = createManifestFile(manifest);
+      return {
+        manifest,
+        files: [...dataFiles, manifestFile],
+      };
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  private async buildBundleContext(params: ExportBundleParams): Promise<BundleContext> {
+    const { projectId, commitId } = params;
+    try {
+      const [projectResponse, commitResponse, elements] = await Promise.all([
+        this.getProject({ projectId }),
+        this.getCommit({ projectId, commitId }),
+        this.fetchAllElementsForBundle(projectId, commitId),
+      ]);
+
+      return {
+        project: projectResponse.data,
+        commit: commitResponse.data,
+        elements: sortElements(elements),
+        generatedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.transformError(error);
+    }
+  }
+
+  private async fetchAllElementsForBundle(projectId: string, commitId: string): Promise<ElementRecord[]> {
+    const elements: ElementRecord[] = [];
+    let cursor: string | undefined;
+    const seenCursors = new Set<string>();
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const response = await this.listElements({ projectId, commitId, cursor, limit: DEFAULT_LIST_LIMIT });
+      elements.push(...response.items);
+
+      if (!response.cursor) {
+        break;
+      }
+
+      if (seenCursors.has(response.cursor)) {
+        break;
+      }
+
+      seenCursors.add(response.cursor);
+      cursor = response.cursor;
+    }
+
+    return elements;
   }
 }
 

--- a/tests/api/export.test.ts
+++ b/tests/api/export.test.ts
@@ -1,0 +1,109 @@
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { afterAll, beforeAll, expect } from 'vitest';
+import { sdk } from './fixtures/sdk';
+import { describeIfApi, testIfApi } from './fixtures/test-helpers';
+import { createProjectParams } from './fixtures/project';
+import { requirementDefinitionFixture } from './fixtures/element';
+import { ensureLatestCommit } from './fixtures/commit';
+
+describeIfApi('Bundle exports', () => {
+  const projectParams = createProjectParams();
+  const elementFixture = requirementDefinitionFixture();
+
+  let projectId: string;
+  let commitId: string;
+  let elementId: string;
+
+  beforeAll(async () => {
+    const project = await sdk.createProject(projectParams);
+    projectId = project.data.id;
+
+    const latestCommit = await ensureLatestCommit(projectId, project.data.defaultBranch);
+    commitId = latestCommit.id;
+
+    const element = await sdk.createElement({ projectId, commitId, body: elementFixture.create });
+    elementId = element.data.id;
+  });
+
+  afterAll(async () => {
+    if (projectId) {
+      try {
+        await sdk.deleteProject({ projectId });
+      } catch (error) {
+        console.warn('Failed to delete test project', error);
+      }
+    }
+  });
+
+  testIfApi('exports SysML text bundle with manifest and checksums', async () => {
+    const bundle = await sdk.exportSysMLTextBundle({ projectId, commitId });
+
+    expect(bundle.manifest.format).toBe('sysml-text');
+    expect(bundle.manifest.project.id).toBe(projectId);
+    expect(bundle.manifest.commit.id).toBe(commitId);
+    expect(bundle.manifest.elementCount).toBeGreaterThan(0);
+
+    const manifestFile = bundle.files.find((file) => file.path === 'manifest.json');
+    expect(manifestFile).toBeDefined();
+
+    const manifestFromFile = JSON.parse(manifestFile!.contents);
+    expect(manifestFromFile).toStrictEqual(bundle.manifest);
+
+    const dataFiles = bundle.files.filter((file) => file.path !== 'manifest.json');
+    expect(bundle.manifest.files).toHaveLength(dataFiles.length);
+
+    for (const entry of bundle.manifest.files) {
+      const file = dataFiles.find((item) => item.path === entry.path);
+      expect(file).toBeDefined();
+      expect(entry.checksum).toBe(createChecksum(file!.contents));
+      expect(entry.size).toBe(Buffer.byteLength(file!.contents, 'utf8'));
+    }
+
+    const sysmlFilePath = `elements/${elementId}.sysml`;
+    const sysmlFile = dataFiles.find((file) => file.path === sysmlFilePath);
+    expect(sysmlFile).toBeDefined();
+    expect(sysmlFile!.contents).toContain('RequirementDefinition');
+    expect(sysmlFile!.contents).toContain(elementFixture.create.payload.text[0]);
+  });
+
+  testIfApi('exports API bundle suitable for re-import', async () => {
+    const bundle = await sdk.exportApiBundle({ projectId, commitId });
+
+    expect(bundle.manifest.format).toBe('api-json');
+    expect(bundle.manifest.project.id).toBe(projectId);
+    expect(bundle.manifest.commit.id).toBe(commitId);
+    expect(bundle.manifest.elementCount).toBeGreaterThan(0);
+
+    const manifestFile = bundle.files.find((file) => file.path === 'manifest.json');
+    expect(manifestFile).toBeDefined();
+    const manifestFromFile = JSON.parse(manifestFile!.contents);
+    expect(manifestFromFile).toStrictEqual(bundle.manifest);
+
+    const apiBundleFile = bundle.files.find((file) => file.path === 'api-bundle.json');
+    expect(apiBundleFile).toBeDefined();
+
+    const apiPayload = JSON.parse(apiBundleFile!.contents);
+    expect(apiPayload.format).toBe('api-json');
+    expect(apiPayload.bundleVersion).toBe(bundle.manifest.bundleVersion);
+    expect(Array.isArray(apiPayload.elements)).toBe(true);
+    expect(apiPayload.elements.length).toBe(bundle.manifest.elementCount);
+
+    const elementFromBundle = apiPayload.elements.find((item: any) => item.id === elementId);
+    expect(elementFromBundle).toBeDefined();
+    expect(elementFromBundle.classifierId).toBe(elementFixture.create.classifierId);
+    expect(elementFromBundle.payload).toStrictEqual(elementFixture.create.payload);
+
+    const dataFiles = bundle.files.filter((file) => file.path !== 'manifest.json');
+    for (const entry of bundle.manifest.files) {
+      const file = dataFiles.find((item) => item.path === entry.path);
+      expect(file).toBeDefined();
+      expect(entry.checksum).toBe(createChecksum(file!.contents));
+      expect(entry.size).toBe(Buffer.byteLength(file!.contents, 'utf8'));
+    }
+  });
+});
+
+function createChecksum(contents: string): string {
+  return createHash('sha256').update(contents, 'utf8').digest('hex');
+}


### PR DESCRIPTION
## Summary
- add bundle export types and helpers to the SysML SDK for generating SysML text and API JSON bundles with manifests
- include checksum and version metadata when producing manifests and bundle files
- add integration tests that exercise bundle exports when the SysML API is available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e680ddc484832f8312b3a40f55d5e8