### PR TITLE
feat(editor): add outline rename refactoring UI

### DIFF
--- a/apps/vue-monaco-editor/src/style.css
+++ b/apps/vue-monaco-editor/src/style.css
@@ -243,6 +243,78 @@ body {
   color: #fecaca;
 }
 
+.outline-rename-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.outline-rename-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.outline-rename-header h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.outline-rename-hint {
+  margin: 0;
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.outline-rename-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.outline-rename-field input {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  color: inherit;
+  font-size: 0.85rem;
+}
+
+.outline-rename-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.outline-rename-submit,
+.outline-rename-reset {
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+}
+
+.outline-rename-submit:hover:not(:disabled),
+.outline-rename-reset:hover:not(:disabled) {
+  background: rgba(51, 65, 85, 0.85);
+}
+
+.outline-rename-submit:disabled,
+.outline-rename-reset:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .status-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add an outline rename panel that calls the SysML API and optimistically updates the selected element
- parse rename responses to update outline caches and apply minimal text edits to the Monaco model
- style the rename controls and track outline revisions so list items refresh correctly

## Testing
- npm test *(fails: SysML API unavailable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e680f43618832f9b7abe3e480ce319