### PR TITLE
Improve SysML diff ID reconciliation

### DIFF
--- a/apps/vue-monaco-editor/src/diff-utils.ts
+++ b/apps/vue-monaco-editor/src/diff-utils.ts
@@ -161,10 +161,10 @@ function operationsConflict(left: DiffOperation, right: DiffOperation): boolean 
   }
 
   if (leftEmpty) {
-    return left.start >= right.start && left.start <= right.end;
+    return left.start >= right.start && left.start < right.end;
   }
 
-  return right.start >= left.start && right.start <= left.end;
+  return right.start >= left.start && right.start < left.end;
 }
 
 export function detectConflicts(leftOps: DiffOperation[], rightOps: DiffOperation[]): MergeConflict[] {

--- a/apps/vue-monaco-editor/src/diff-utils.ts
+++ b/apps/vue-monaco-editor/src/diff-utils.ts
@@ -1,0 +1,230 @@
+export interface DiffOperation {
+  start: number;
+  end: number;
+  replacement: string[];
+}
+
+export interface MergeConflict {
+  left: DiffOperation;
+  right: DiffOperation;
+}
+
+export interface MergeResult {
+  mergedText: string;
+  leftOperations: DiffOperation[];
+  rightOperations: DiffOperation[];
+  conflicts: MergeConflict[];
+}
+
+function splitLines(text: string): string[] {
+  if (!text) {
+    return [];
+  }
+  const normalized = text.replace(/\r\n?/g, '\n');
+  if (normalized.endsWith('\n')) {
+    return normalized.slice(0, -1).split('\n').concat('');
+  }
+  return normalized.split('\n');
+}
+
+function diffOpKey(op: DiffOperation): string {
+  return `${op.start}:${op.end}:${op.replacement.join('\u0000')}`;
+}
+
+function applyOperations(baseLines: string[], operations: DiffOperation[]): string[] {
+  if (!operations.length) {
+    return baseLines.slice();
+  }
+  const sorted = operations
+    .filter((op) => op.start >= 0 && op.end >= op.start)
+    .sort((a, b) => {
+      if (a.start !== b.start) {
+        return b.start - a.start;
+      }
+      return b.end - a.end;
+    });
+
+  const result = baseLines.slice();
+  for (const op of sorted) {
+    const removeCount = op.end - op.start;
+    result.splice(op.start, removeCount, ...op.replacement);
+  }
+  return result;
+}
+
+function coalesceOperations(operations: DiffOperation[]): DiffOperation[] {
+  const filtered = operations.filter((op) => op.start !== op.end || op.replacement.length > 0);
+  if (filtered.length <= 1) {
+    return filtered;
+  }
+  const merged: DiffOperation[] = [];
+  let current = filtered[0];
+  for (let index = 1; index < filtered.length; index += 1) {
+    const next = filtered[index];
+    if (current.end === next.start) {
+      current = {
+        start: current.start,
+        end: next.end,
+        replacement: current.replacement.concat(next.replacement),
+      };
+    } else {
+      merged.push(current);
+      current = next;
+    }
+  }
+  merged.push(current);
+  return merged;
+}
+
+export function computeDiffOperations(baseText: string, otherText: string): DiffOperation[] {
+  const baseLines = splitLines(baseText);
+  const otherLines = splitLines(otherText);
+  const n = baseLines.length;
+  const m = otherLines.length;
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      if (baseLines[i] === otherLines[j]) {
+        dp[i][j] = dp[i + 1][j + 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+      }
+    }
+  }
+
+  const operations: DiffOperation[] = [];
+  let i = 0;
+  let j = 0;
+  let current: DiffOperation | null = null;
+
+  const flush = () => {
+    if (current) {
+      if (current.start !== current.end || current.replacement.length > 0) {
+        operations.push(current);
+      }
+      current = null;
+    }
+  };
+
+  while (i < n || j < m) {
+    if (i < n && j < m && baseLines[i] === otherLines[j]) {
+      flush();
+      i += 1;
+      j += 1;
+      continue;
+    }
+
+    const down = i < n ? dp[i + 1][j] : -1;
+    const right = j < m ? dp[i][j + 1] : -1;
+
+    if (j < m && (i === n || right >= down)) {
+      if (!current) {
+        current = { start: i, end: i, replacement: [] };
+      }
+      current.replacement.push(otherLines[j]);
+      j += 1;
+      continue;
+    }
+
+    if (i < n) {
+      if (!current) {
+        current = { start: i, end: i, replacement: [] };
+      }
+      current.end += 1;
+      i += 1;
+      continue;
+    }
+
+    break;
+  }
+
+  flush();
+
+  return coalesceOperations(operations);
+}
+
+function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return Math.max(aStart, bStart) < Math.min(aEnd, bEnd);
+}
+
+function operationsConflict(left: DiffOperation, right: DiffOperation): boolean {
+  const leftEmpty = left.start === left.end;
+  const rightEmpty = right.start === right.end;
+
+  if (!leftEmpty && !rightEmpty) {
+    return rangesOverlap(left.start, left.end, right.start, right.end);
+  }
+
+  if (leftEmpty && rightEmpty) {
+    return left.start === right.start;
+  }
+
+  if (leftEmpty) {
+    return left.start >= right.start && left.start <= right.end;
+  }
+
+  return right.start >= left.start && right.start <= left.end;
+}
+
+export function detectConflicts(leftOps: DiffOperation[], rightOps: DiffOperation[]): MergeConflict[] {
+  const conflicts: MergeConflict[] = [];
+  for (const left of leftOps) {
+    for (const right of rightOps) {
+      if (operationsConflict(left, right)) {
+        conflicts.push({ left, right });
+      }
+    }
+  }
+  return conflicts;
+}
+
+function mergePreferRight(
+  baseLines: string[],
+  leftOps: DiffOperation[],
+  rightOps: DiffOperation[],
+  conflicts: MergeConflict[],
+): string[] {
+  const conflictLeftKeys = new Set(conflicts.map((conflict) => diffOpKey(conflict.left)));
+  const operationsMap = new Map<string, DiffOperation>();
+
+  for (const op of rightOps) {
+    operationsMap.set(diffOpKey(op), op);
+  }
+
+  for (const op of leftOps) {
+    const key = diffOpKey(op);
+    if (conflictLeftKeys.has(key)) {
+      continue;
+    }
+    if (!operationsMap.has(key)) {
+      operationsMap.set(key, op);
+    }
+  }
+
+  return applyOperations(baseLines, Array.from(operationsMap.values()));
+}
+
+export function mergeChanges(baseText: string, leftText: string, rightText: string): MergeResult {
+  const baseLines = splitLines(baseText);
+  const leftOps = computeDiffOperations(baseText, leftText);
+  const rightOps = computeDiffOperations(baseText, rightText);
+  const conflicts = detectConflicts(leftOps, rightOps);
+  const mergedLines = mergePreferRight(baseLines, leftOps, rightOps, conflicts);
+
+  return {
+    mergedText: mergedLines.join('\n'),
+    leftOperations: leftOps,
+    rightOperations: rightOps,
+    conflicts,
+  };
+}
+
+export function formatLineRange(start: number, end: number): string {
+  const first = start + 1;
+  const last = Math.max(end, start + 1);
+  if (first === last) {
+    return `line ${first}`;
+  }
+  return `lines ${first}-${last}`;
+}

--- a/apps/vue-monaco-editor/src/style.css
+++ b/apps/vue-monaco-editor/src/style.css
@@ -95,6 +95,42 @@ body {
   inset: 0;
 }
 
+.merge-container {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  background: rgba(15, 23, 42, 0.85);
+  gap: 1px;
+}
+
+.merge-pane {
+  position: relative;
+  background: rgba(15, 23, 42, 0.95);
+  overflow: hidden;
+}
+
+.merge-pane:not(:first-child) {
+  border-left: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.merge-pane-label {
+  position: absolute;
+  top: 0.35rem;
+  left: 0.6rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.merge-editor {
+  position: absolute;
+  inset: 0;
+}
+
 .sidebar {
   border-left: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(15, 23, 42, 0.65);
@@ -161,6 +197,137 @@ body {
   padding: 0.3rem 0.6rem;
   color: inherit;
   font-size: 0.8125rem;
+}
+
+.diff-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.diff-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.diff-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.diff-clear {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+  font-size: 0.8125rem;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+}
+
+.diff-clear:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.diff-config {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.diff-config label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.diff-config input {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  color: inherit;
+  font-size: 0.8125rem;
+}
+
+.diff-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.diff-primary,
+.diff-secondary {
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(30, 41, 59, 0.8);
+  color: inherit;
+}
+
+.diff-primary {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
+.diff-primary:disabled,
+.diff-secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.diff-hint {
+  opacity: 0.7;
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.diff-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #f87171;
+}
+
+.diff-status {
+  margin: 0;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.diff-conflicts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.diff-conflicts h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.diff-conflicts ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.diff-conflicts li {
+  line-height: 1.35;
+}
+
+.diff-conflicts p {
+  margin: 0.2rem 0 0;
+  opacity: 0.8;
 }
 
 .outline-body {

--- a/tests/diff/diff-utils.test.ts
+++ b/tests/diff/diff-utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  computeDiffOperations,
+  detectConflicts,
+  formatLineRange,
+  mergeChanges,
+  type DiffOperation,
+} from '../../apps/vue-monaco-editor/src/diff-utils';
+
+function toText(lines: string[]): string {
+  return lines.join('\n');
+}
+
+describe('diff utilities', () => {
+  test('computes diff operations for insertions and replacements', () => {
+    const base = toText(['alpha', 'beta', 'gamma']);
+    const modified = toText(['alpha', 'beta', 'gamma', 'delta']);
+    const replacement = toText(['alpha', 'BETA', 'gamma']);
+
+    const insertOps = computeDiffOperations(base, modified);
+    expect(insertOps).toHaveLength(1);
+    expect(insertOps[0]).toEqual({ start: 3, end: 3, replacement: ['delta'] });
+
+    const replaceOps = computeDiffOperations(base, replacement);
+    expect(replaceOps).toHaveLength(1);
+    expect(replaceOps[0]).toEqual({ start: 1, end: 2, replacement: ['BETA'] });
+  });
+
+  test('detects conflicting operations', () => {
+    const base = toText(['a', 'b', 'c']);
+    const leftOps: DiffOperation[] = [{ start: 1, end: 2, replacement: ['B'] }];
+    const rightOps: DiffOperation[] = [{ start: 1, end: 2, replacement: ['beta'] }];
+
+    const conflicts = detectConflicts(leftOps, rightOps);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({ left: leftOps[0], right: rightOps[0] });
+  });
+
+  test('detects conflicts for competing insertions', () => {
+    const leftOps: DiffOperation[] = [{ start: 1, end: 1, replacement: ['left'] }];
+    const rightOps: DiffOperation[] = [{ start: 1, end: 1, replacement: ['right'] }];
+
+    const conflicts = detectConflicts(leftOps, rightOps);
+    expect(conflicts).toHaveLength(1);
+  });
+
+  test('merges non-conflicting changes from both sides', () => {
+    const base = toText(['a', 'b', 'c']);
+    const left = toText(['a', 'B', 'c']);
+    const right = toText(['a', 'b', 'c', 'd']);
+
+    const result = mergeChanges(base, left, right);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.mergedText).toBe(toText(['a', 'B', 'c', 'd']));
+  });
+
+  test('prefers right side when conflicts occur', () => {
+    const base = toText(['a', 'b', 'c']);
+    const left = toText(['a', 'B', 'c']);
+    const right = toText(['a', 'beta', 'c']);
+
+    const result = mergeChanges(base, left, right);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.mergedText).toBe(right);
+  });
+
+  test('formats line ranges for summaries', () => {
+    expect(formatLineRange(0, 1)).toBe('line 1');
+    expect(formatLineRange(2, 5)).toBe('lines 3-5');
+  });
+});


### PR DESCRIPTION
## Summary
* Added diff and merge UI to the Monaco editor shell, including separate containers for two-way diffs, a three-pane merge layout, and a sidebar section for configuring commit comparisons.
* Introduced state, lifecycle wiring, and helper functions in `App.vue` to fetch commit content, reconcile SysML element IDs through the API, compute diffs/merge outcomes, and manage Monaco models for the new views.
* Implemented reusable diff/merge utilities (`computeDiffOperations`, `detectConflicts`, `mergeChanges`, etc.) in a new module for testing and integration.
* Extended styles to support the new diff/merge controls and layout.
* Added Vitest coverage for diff utilities across insertions, replacements, conflict detection, merge preferences, and range formatting.
* Improved ID reconciliation to handle quoted identifiers and names containing punctuation so merge views always reflect the server's canonical IDs.

## Testing
* `npm test` *(fails: vitest CLI is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6812ab8cc832f89cdbdfe9b401ba8