### PR TITLE
Improve import quick fix heuristics

### DIFF
--- a/apps/vue-monaco-editor/src/App.vue
+++ b/apps/vue-monaco-editor/src/App.vue
@@ -3600,7 +3600,7 @@ function applyMarkers(issues: NormalizedIssue[]) {
     endLineNumber: issue.range.endLineNumber,
     endColumn: issue.range.endColumn,
     tags:
-      issue.quickFixes.length || inferImportCandidates(issue).length
+      issue.quickFixes.length || inferImportCandidates(issue, model).length
         ? [monacoApi!.MarkerTag.Unnecessary]
         : undefined,
     relatedInformation: issue.elementId
@@ -4025,7 +4025,7 @@ function deriveHeuristicFixes(
   issue: NormalizedIssue,
   model: Monaco.editor.ITextModel,
 ): NormalizedFix[] {
-  const candidates = inferImportCandidates(issue);
+  const candidates = inferImportCandidates(issue, model);
   if (!candidates.length) {
     return [];
   }
@@ -4059,7 +4059,10 @@ function deriveHeuristicFixes(
   return fixes;
 }
 
-function inferImportCandidates(issue: NormalizedIssue): string[] {
+function inferImportCandidates(
+  issue: NormalizedIssue,
+  model?: Monaco.editor.ITextModel | null,
+): string[] {
   const message = issue.message;
   const matches: string[] = [];
 
@@ -4068,6 +4071,7 @@ function inferImportCandidates(issue: NormalizedIssue): string[] {
     /unresolved\s+(?:reference|ref(?:erence)?|identifier|element)\s+(?:to|for|of)?\s*(?:element\s+)?['"]?([\w.:]+)['"]?/i,
     /cannot\s+resolve\s+(?:reference|ref(?:erence)?|identifier|element)\s+(?:to|for|of)?\s*(?:element\s+)?['"]?([\w.:]+)['"]?/i,
     /no\s+import\s+(?:for|of)\s+(?:element\s+)?['"]?([\w.:]+)['"]?/i,
+    /import\s+required\s+for\s+(?:element\s+)?['"]?([\w.:]+)['"]?/i,
   ];
 
   for (const pattern of patterns) {
@@ -4080,15 +4084,59 @@ function inferImportCandidates(issue: NormalizedIssue): string[] {
     }
   }
 
+  if (typeof issue.elementId === 'string') {
+    const sanitized = sanitizeImportCandidate(issue.elementId);
+    if (sanitized) {
+      matches.push(sanitized);
+    }
+  }
+
+  if (model) {
+    const rangeText = model.getValueInRange({
+      startLineNumber: issue.range.startLineNumber,
+      startColumn: issue.range.startColumn,
+      endLineNumber: issue.range.endLineNumber,
+      endColumn: issue.range.endColumn,
+    });
+    if (rangeText) {
+      const sanitized = sanitizeImportCandidate(rangeText);
+      if (sanitized) {
+        matches.push(sanitized);
+      }
+    }
+
+    const word = model.getWordAtPosition({
+      lineNumber: issue.range.startLineNumber,
+      column: issue.range.startColumn,
+    });
+    if (word?.word) {
+      const sanitized = sanitizeImportCandidate(word.word);
+      if (sanitized) {
+        matches.push(sanitized);
+      }
+    }
+  }
+
   return Array.from(new Set(matches));
 }
 
 function sanitizeImportCandidate(value: string): string | null {
-  const trimmed = value.trim().replace(/[.;:]+$/, '').replace(/^:+/, '');
+  const trimmed = value.trim();
   if (!trimmed) {
     return null;
   }
-  return trimmed;
+
+  const withoutPrefix = trimmed
+    .replace(/^(?:public|private)\s+import\s+/i, '')
+    .replace(/^(?:import\s+)?(?:required\s+for\s+)?/i, '')
+    .replace(/^element\s+/i, '');
+
+  const token = withoutPrefix.split(/\s+/)[0] ?? '';
+  const normalized = token.replace(/[.;:]+$/, '').replace(/^:+/, '');
+  if (!normalized) {
+    return null;
+  }
+  return normalized;
 }
 
 function computeImportInsertionRange(model: Monaco.editor.ITextModel): NormalizedRange | null {
@@ -4169,7 +4217,7 @@ function badgeFixes(issue: NormalizedIssue): string[] {
   if (issue.quickFixes.length) {
     return issue.quickFixes.map((fix) => fix.title);
   }
-  const inferred = inferImportCandidates(issue);
+  const inferred = inferImportCandidates(issue, editorRef.value?.getModel() ?? null);
   if (inferred.length) {
     return inferred.map((identifier) => `Insert public import ${identifier}`);
   }

--- a/apps/vue-monaco-editor/src/App.vue
+++ b/apps/vue-monaco-editor/src/App.vue
@@ -4074,14 +4074,21 @@ function inferImportCandidates(
     /import\s+required\s+for\s+(?:element\s+)?['"]?([\w.:]+)['"]?/i,
   ];
 
+  let messageIndicatesImport = false;
+
   for (const pattern of patterns) {
     const match = pattern.exec(message);
     if (match && match[1]) {
+      messageIndicatesImport = true;
       const sanitized = sanitizeImportCandidate(match[1]);
       if (sanitized) {
         matches.push(sanitized);
       }
     }
+  }
+
+  if (!messageIndicatesImport) {
+    return Array.from(new Set(matches));
   }
 
   if (typeof issue.elementId === 'string') {


### PR DESCRIPTION
## Summary
- expand heuristic import suggestions to inspect diagnostics, element ids, and source text
- sanitize suggested identifiers before offering quick fixes and reuse editor models when computing tags and badges

## Testing
- pnpm --filter vue-monaco-editor run build *(fails: No projects matched the filters in "/workspace/SysML-v2-Release")*

------
https://chatgpt.com/codex/tasks/task_e_68e70052f500832fa9b90b6fb34bac24