### PR TITLE
Add Playwright editor workflow test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Icon?
+
+# Playwright runtime artifacts
+tests/playwright/.runtime/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "dev:editor": "vite --config apps/vue-monaco-editor/vite.config.ts",
     "build:editor": "vite build --config apps/vue-monaco-editor/vite.config.ts",
-    "preview:editor": "vite preview --config apps/vue-monaco-editor/vite.config.ts"
+    "preview:editor": "vite preview --config apps/vue-monaco-editor/vite.config.ts",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@monaco-editor/loader": "^1.4.0",
@@ -24,6 +25,7 @@
     "@vitejs/plugin-vue": "^5.0.5",
     "typescript": "^5.5.4",
     "vite": "^5.3.4",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@playwright/test": "^1.50.0"
   }
 }

--- a/tests/playwright/docker-compose.playwright.yml
+++ b/tests/playwright/docker-compose.playwright.yml
@@ -1,0 +1,38 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: sysml2
+      POSTGRES_USER: sysml2
+      POSTGRES_PASSWORD: sysml2
+    volumes:
+      - ./fixtures/postgres-seed:/docker-entrypoint-initdb.d:ro
+      - playwright-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    image: ghcr.io/systems-modeling/sysml-v2-api-services:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/sysml2
+      SPRING_DATASOURCE_USERNAME: sysml2
+      SPRING_DATASOURCE_PASSWORD: sysml2
+    ports:
+      - '9000:9000'
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -fsS http://localhost:9000/docs || exit 1']
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+volumes:
+  playwright-postgres-data:

--- a/tests/playwright/fixtures/postgres-seed/001-playwright-seed.sql
+++ b/tests/playwright/fixtures/postgres-seed/001-playwright-seed.sql
@@ -1,0 +1,7 @@
+-- Seeded schema for Playwright integration tests.
+-- The SysML v2 API container performs all schema migrations automatically.
+-- This script simply ensures deterministic database settings before the
+-- migrations run and acts as a marker that the seeded volume was applied.
+\connect sysml2
+SET TIME ZONE 'UTC';
+COMMENT ON DATABASE sysml2 IS 'Playwright seeded baseline';

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+
+const testDir = path.join(__dirname, 'specs');
+const outputDir = path.join(__dirname, 'artifacts');
+
+export default defineConfig({
+  testDir,
+  outputDir,
+  timeout: 5 * 60 * 1000,
+  fullyParallel: false,
+  expect: {
+    timeout: 15_000,
+  },
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { outputFolder: path.join(outputDir, 'html-report') }]],
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  globalSetup: path.join(__dirname, 'scripts', 'global-setup.ts'),
+  globalTeardown: path.join(__dirname, 'scripts', 'global-teardown.ts'),
+  webServer: {
+    command: 'npm run dev:editor -- --host 127.0.0.1 --port 4173',
+    port: 4173,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});

--- a/tests/playwright/scripts/global-setup.ts
+++ b/tests/playwright/scripts/global-setup.ts
@@ -1,0 +1,142 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { FullConfig } from '@playwright/test';
+
+import { SysMLSDK } from '../../../src/sysml-sdk';
+import type { CommitSummary } from '../../../src/generated/types';
+
+const API_BASE_URL = 'http://localhost:9000/api';
+const VALIDATION_ENDPOINT = `${API_BASE_URL}/validation`;
+
+interface RuntimeProjectConfig {
+  projectId: string;
+  branchId: string;
+  commitId: string;
+  rootElementId: string;
+}
+
+interface RuntimeConfig {
+  apiBaseUrl: string;
+  validationUrl: string;
+  project: RuntimeProjectConfig;
+}
+
+async function ensureDirectory(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function runDockerCommand(rootDir: string, args: string[]): void {
+  const composeFile = path.join(rootDir, 'tests', 'playwright', 'docker-compose.playwright.yml');
+  const command = ['docker', 'compose', '-f', composeFile, ...args].join(' ');
+  execSync(command, { stdio: 'inherit' });
+}
+
+async function waitForApiReady(url: string, attempts = 60, delayMs = 2000): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetch(`${url}/projects?limit=1`);
+      if (response.ok) {
+        return;
+      }
+    } catch (error) {
+      // ignore until max attempts
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw new Error('SysML API did not become ready in time.');
+}
+
+async function ensureSeedProject(sdk: SysMLSDK): Promise<RuntimeProjectConfig> {
+  const seedName = 'playwright-seed-project';
+  const projects = await sdk.listProjects({ search: seedName, limit: 10 });
+  for (const project of projects.items) {
+    if (project.name === seedName) {
+      await sdk.deleteProject({ projectId: project.id });
+    }
+  }
+
+  const projectResponse = await sdk.createProject({
+    body: {
+      name: seedName,
+      description: 'Playwright integration tests for SysML editor.',
+      defaultBranch: 'main',
+    },
+  });
+
+  const project = projectResponse.data;
+  const commit = await ensureLatestCommit(sdk, project.id, project.defaultBranch);
+
+  const rootElement = await sdk.createElement({
+    projectId: project.id,
+    commitId: commit.id,
+    body: {
+      classifierId: 'sysml:Package',
+      name: 'PlaywrightRoot',
+      documentation: 'Root package created for Playwright UI tests.',
+      payload: {
+        '@type': 'Package',
+        declaredName: 'PlaywrightRoot',
+        declaredShortName: 'Playwright',
+      },
+    },
+  });
+
+  return {
+    projectId: project.id,
+    branchId: project.defaultBranch,
+    commitId: commit.id,
+    rootElementId: rootElement.data.id,
+  };
+}
+
+async function ensureLatestCommit(
+  sdk: SysMLSDK,
+  projectId: string,
+  branchId: string,
+): Promise<CommitSummary> {
+  const commits = await sdk.listCommits({ projectId, branchId, limit: 1 });
+  const latest = commits.items.at(0);
+  if (latest) {
+    return latest;
+  }
+  const created = await sdk.createCommit({
+    projectId,
+    body: {
+      message: 'Initialize branch for Playwright integration tests',
+      branchId,
+      operations: [],
+    },
+  });
+  return created.data;
+}
+
+async function globalSetup(_config: FullConfig): Promise<void> {
+  const rootDir = path.resolve(__dirname, '../../..');
+  const runtimeDir = path.join(rootDir, 'tests', 'playwright', '.runtime');
+  await ensureDirectory(runtimeDir);
+
+  try {
+    runDockerCommand(rootDir, ['down', '--remove-orphans', '--volumes']);
+  } catch (error) {
+    // The first run will fail because nothing is running yet. Ignore.
+  }
+
+  runDockerCommand(rootDir, ['up', '-d', '--wait']);
+  await waitForApiReady(API_BASE_URL);
+
+  const sdk = new SysMLSDK({ baseUrl: API_BASE_URL });
+  const project = await ensureSeedProject(sdk);
+
+  const runtimeConfig: RuntimeConfig = {
+    apiBaseUrl: API_BASE_URL,
+    validationUrl: VALIDATION_ENDPOINT,
+    project,
+  };
+
+  const configPath = path.join(runtimeDir, 'runtime-config.json');
+  await fs.writeFile(configPath, JSON.stringify(runtimeConfig, null, 2), 'utf-8');
+}
+
+export default globalSetup;

--- a/tests/playwright/scripts/global-teardown.ts
+++ b/tests/playwright/scripts/global-teardown.ts
@@ -1,0 +1,14 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+export default async function globalTeardown(): Promise<void> {
+  const rootDir = path.resolve(__dirname, '../../..');
+  const composeFile = path.join(rootDir, 'tests', 'playwright', 'docker-compose.playwright.yml');
+  try {
+    execSync(`docker compose -f ${composeFile} down --remove-orphans --volumes`, {
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    // Ignore teardown failures so they do not mask test results.
+  }
+}

--- a/tests/playwright/specs/editor-e2e.spec.ts
+++ b/tests/playwright/specs/editor-e2e.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+interface RuntimeProjectConfig {
+  projectId: string;
+  branchId: string;
+  commitId: string;
+  rootElementId: string;
+}
+
+interface RuntimeConfig {
+  apiBaseUrl: string;
+  validationUrl: string;
+  project: RuntimeProjectConfig;
+}
+
+let runtimeConfig: RuntimeConfig;
+
+async function loadRuntimeConfig(): Promise<RuntimeConfig> {
+  const configPath = path.resolve(__dirname, '..', '.runtime', 'runtime-config.json');
+  const buffer = await fs.readFile(configPath, 'utf-8');
+  return JSON.parse(buffer) as RuntimeConfig;
+}
+
+test.beforeAll(async () => {
+  runtimeConfig = await loadRuntimeConfig();
+});
+
+test('authoring and modeling workflow', async ({ page }) => {
+  const { apiBaseUrl, validationUrl, project } = runtimeConfig;
+
+  await page.goto('/');
+
+  await page.getByLabel('Validation endpoint').fill(validationUrl);
+
+  const sysmlSnippet = [
+    'package Playwright::Example {',
+    '  part controller : Controller { id = ctrl_controller; }',
+    '',
+    '  block Controller {',
+    '    attribute desiredSpeed : Real;',
+    '  }',
+    '}',
+  ].join('\n');
+
+  const editorTextArea = page.locator('.monaco-editor textarea').first();
+  await editorTextArea.click();
+  await page.keyboard.press('Control+A');
+  await page.keyboard.type(sysmlSnippet, { delay: 10 });
+
+  await page.getByRole('button', { name: /Validate now/i }).click();
+  await expect(page.locator('.status-pill')).toContainText(/No diagnostics|diagnostic/i);
+
+  await page.getByLabel('API base URL').fill(apiBaseUrl);
+  await page.getByLabel('Project ID').fill(project.projectId);
+  await page.getByLabel('Commit ID').fill(project.commitId);
+  await page.getByLabel('Root element ID').fill(project.rootElementId);
+  await page.locator('.outline-refresh').click();
+
+  await expect(page.getByRole('treeitem', { name: /PlaywrightRoot/i })).toBeVisible();
+
+  const blockPanel = page.locator('.wizard-panel').filter({ hasText: 'New Block' });
+  await blockPanel.locator('summary').click();
+  await blockPanel.getByLabel('Name').fill('WheelController');
+  await blockPanel.getByLabel('Short name (optional)').fill('WheelCtrl');
+  await blockPanel.getByLabel('Documentation (optional)').fill('Created during Playwright test run.');
+
+  await page.getByRole('treeitem', { name: /PlaywrightRoot/i }).click();
+  await blockPanel.getByRole('button', { name: /Create block/i }).click();
+  await expect(blockPanel.locator('.wizard-feedback.success')).toContainText(/created|commit/i);
+
+  await expect(page.getByRole('treeitem', { name: /WheelController/i })).toBeVisible();
+
+  const diagramInfo = await page.evaluate(async ({ apiBaseUrl: baseUrl, projectId, commitId }) => {
+    const { buildBlockConnectorGraph, layoutBlockConnectorGraph } = await import('/src/graph/index.ts');
+    const response = await fetch(
+      `${baseUrl}/projects/${encodeURIComponent(projectId)}/commits/${encodeURIComponent(commitId)}/elements?classifierId=sysml:BlockDefinition&limit=100`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to load elements for diagram (${response.status})`);
+    }
+    const payload = await response.json();
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const graph = buildBlockConnectorGraph(items);
+    const layout = await layoutBlockConnectorGraph(graph, { direction: 'RIGHT' });
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('id', 'playwright-block-diagram');
+    svg.setAttribute('viewBox', '0 0 800 600');
+    svg.style.width = '480px';
+    svg.style.height = '360px';
+    svg.style.border = '1px solid currentColor';
+
+    for (const node of graph.nodes) {
+      const layoutNode = layout.nodes[node.id];
+      if (!layoutNode) continue;
+      const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      group.setAttribute('transform', `translate(${layoutNode.x}, ${layoutNode.y})`);
+      const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('width', String(layoutNode.width));
+      rect.setAttribute('height', String(layoutNode.height));
+      rect.setAttribute('rx', '8');
+      rect.setAttribute('fill', '#1f2937');
+      rect.setAttribute('stroke', '#60a5fa');
+      rect.setAttribute('stroke-width', '2');
+      group.appendChild(rect);
+
+      const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      label.textContent = node.label || node.elementId;
+      label.setAttribute('x', '12');
+      label.setAttribute('y', '28');
+      label.setAttribute('fill', '#f9fafb');
+      label.setAttribute('font-size', '18');
+      label.setAttribute('font-family', 'Inter, sans-serif');
+      group.appendChild(label);
+
+      svg.appendChild(group);
+    }
+
+    document.body.appendChild(svg);
+    return { nodeCount: graph.nodes.length, edgeCount: graph.edges.length };
+  }, {
+    apiBaseUrl,
+    projectId: project.projectId,
+    commitId: project.commitId,
+  });
+
+  await expect(page.locator('#playwright-block-diagram')).toBeVisible();
+  expect(diagramInfo.nodeCount).toBeGreaterThan(0);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "@playwright/test"],
     "lib": ["ES2022", "DOM"],
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
## Summary
- add Playwright configuration, seeded Docker Compose harness, and runtime ignore rules
- implement Playwright global setup/teardown to launch the SysML API with a seeded Postgres volume
- cover validation, block creation, and diagram rendering in a new editor end-to-end test

## Testing
- not run (requires Docker and Playwright browsers)

------
https://chatgpt.com/codex/tasks/task_e_68e7006f010c832f97d34d502150a75c